### PR TITLE
立ち絵の変換ができたか確認して表示を切り替えるように変更。 #1487

### DIFF
--- a/src/components/accessories/DisplayMoviePicFile.vue
+++ b/src/components/accessories/DisplayMoviePicFile.vue
@@ -45,6 +45,9 @@ const getKyaraImg = async (profile: encodeProfileSendReType) => {
       reader.onload = () => {
         img.value = reader.result
 
+        // 立ち絵が存在するのでfalesにする
+        noTatieFile.value = false
+
         // 終わったので戻す
         runMakeImg.value = true
       }
@@ -95,7 +98,11 @@ onUnmounted(() => {
 
 <template>
   <img
-    v-if="profile.settingList.tatie.tatieUUID.val !== DEFAULT_KYARA_TATIE_UUID && typeof img === 'string'"
+    v-if="
+      profile.settingList.tatie.tatieUUID.val !== DEFAULT_KYARA_TATIE_UUID &&
+      typeof img === 'string' &&
+      noTatieFile !== true
+    "
     :src="img"
     :class="imgClass"
     @click="() => saveImg()"


### PR DESCRIPTION
## Pull Request 概要

立ち絵の変換に失敗すると、最後に変換に成功した立ち絵を左上に表示してしまうのを修正しました。

## 変更点

立ち絵の変換に失敗した場合、失敗したことを左上に表示するようにしました。

## その他


