### PR TITLE
複数人を登場させる場合、しゃべっていない相方の立ち絵も表示

### DIFF
--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -24,7 +24,12 @@ export interface WGyomAPI {
   getKyraPicFileData: (fileName: string, sizeHeight?: number) => Uint8Array
   opneKyaraPicFileDir: (defoDir?: string) => { uuid: string; name: string; extname: string }[]
   getFileListKyaraData: () => string
-  enterEncodeVideoData: (dirPathName: string, outJsonData: string, infoSettingJsonData: string) => string
+  enterEncodeVideoData: (
+    dirPathName: string,
+    outJsonData: string,
+    outTatieState: { outJsonData: string; tatieSituation: string }[],
+    infoSettingJsonData: string,
+  ) => string
   getGlobalSettingData: () => string
   writeGlobalSettingData: (outJsonData: string) => boolean
   openGlobalSetting: (listener: () => void) => void

--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -30,7 +30,10 @@ export interface WGyomAPI {
   openGlobalSetting: (listener: () => void) => void
   getJsonFileData: (fileType: string, fileName?: string) => string
   writeJsonFileData: (fileType: string, outJsonData: string, fileName?: string) => boolean
-  getEncodePicFileData: (outJsonData: string) => { buffer: Uint8Array; path: string }
+  getEncodePicFileData: (outState: { outJsonData: string; tatieSituation: string }[]) => {
+    buffer: Uint8Array
+    path: string
+  }
   writeUint8ArrayFileData: (
     fileData: Uint8Array,
     fileName: string,

--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -24,7 +24,7 @@ export interface WGyomAPI {
   getKyraPicFileData: (fileName: string, sizeHeight?: number) => Uint8Array
   opneKyaraPicFileDir: (defoDir?: string) => { uuid: string; name: string; extname: string }[]
   getFileListKyaraData: () => string
-  enterEncodeVideoData: (dirPathName: string, outJsonData: string) => string
+  enterEncodeVideoData: (dirPathName: string, outJsonData: string, infoSettingJsonData: string) => string
   getGlobalSettingData: () => string
   writeGlobalSettingData: (outJsonData: string) => boolean
   openGlobalSetting: (listener: () => void) => void

--- a/src/components/accessories/DisplayMoviePicFile.vue
+++ b/src/components/accessories/DisplayMoviePicFile.vue
@@ -125,7 +125,9 @@ watch(
 <template>
   <img
     v-if="
-      profile?.tatie[tatieSituation].val !== DEFAULT_KYARA_TATIE_UUID && typeof img === 'string' && noTatieFile !== true
+      (settype === 'tatieOrder' || profile?.tatie[tatieSituation].val !== DEFAULT_KYARA_TATIE_UUID) &&
+      typeof img === 'string' &&
+      noTatieFile !== true
     "
     :src="img"
     :class="imgClass"

--- a/src/components/accessories/DisplayMoviePicFile.vue
+++ b/src/components/accessories/DisplayMoviePicFile.vue
@@ -109,6 +109,7 @@ const getKyaraImg = async (index?: number) => {
       props.settype,
       props.tatieOrderList,
     )
+    ChangeKyaraImg()
   }
 }
 
@@ -124,7 +125,7 @@ const saveImg = async () => {
 
 watch(
   () => {
-    props.profile, props.settype, props.tatieSituation
+    props.profile, props.settype, props.tatieSituation, props.tatieOrderList
   },
   () => {
     if (props.settype === 'tatieOrder') {

--- a/src/components/accessories/DisplayMoviePicFile.vue
+++ b/src/components/accessories/DisplayMoviePicFile.vue
@@ -30,9 +30,9 @@ const noTatieFile = ref<boolean>(false)
 // 変換した立ち絵画像を取得
 const img = ref<string | ArrayBuffer>()
 const data = ref<{ buffer: Uint8Array; path: string }>({ buffer: undefined, path: '' })
-const getKyaraImg = async (profile: encodeProfileSendReType) => {
+const getKyaraImg = async (profile: outSettingType) => {
   // 立ち絵があり、他の画像取得が動作していない場合のみ実施
-  if (profile.settingList.tatie[props.tatieSituation].val !== DEFAULT_KYARA_TATIE_UUID && runMakeImg) {
+  if (profile.tatie[props.tatieSituation].val !== DEFAULT_KYARA_TATIE_UUID && runMakeImg) {
     // 二重起動しないように値を変更
     runMakeImg.value = false
 
@@ -75,17 +75,15 @@ const saveImg = async () => {
 }
 
 // コンポーネント表示時に、立ち絵画像の表示をも行う
-const profile = ref<encodeProfileSendReType>(
-  createVoiceFileEncodeSetting(props.dateList[props.index], props.index, props.dateList, props.infoData),
-)
+const profile = ref<outSettingType>(createVoiceFileEncodeSetting(props.index, props.dateList))
 getKyaraImg(profile.value)
-const checkConf = ref<string>(JSON.stringify(profile.value.settingList.tatie, undefined, 2))
+const checkConf = ref<string>(JSON.stringify(profile.value.tatie, undefined, 2))
 
 // 指定時間ごとに確認し、立ち絵の設定が変わったら表示を変更する
 const onEncodeTatie = setInterval(() => {
   // 比較のために設定内容をJSON形式に変換
-  profile.value = createVoiceFileEncodeSetting(props.dateList[props.index], props.index, props.dateList, props.infoData)
-  const ans = JSON.stringify([profile.value.settingList.tatie, props.tatieSituation], undefined, 2)
+  profile.value = createVoiceFileEncodeSetting(props.index, props.dateList)
+  const ans = JSON.stringify([profile.value.tatie, props.tatieSituation], undefined, 2)
 
   // 比較して前回の内容と異なっていれば立ち絵画像の表示を更新する。
   if (checkConf.value !== ans) {
@@ -103,9 +101,7 @@ onUnmounted(() => {
 <template>
   <img
     v-if="
-      profile.settingList.tatie[tatieSituation].val !== DEFAULT_KYARA_TATIE_UUID &&
-      typeof img === 'string' &&
-      noTatieFile !== true
+      profile.tatie[tatieSituation].val !== DEFAULT_KYARA_TATIE_UUID && typeof img === 'string' && noTatieFile !== true
     "
     :src="img"
     :class="imgClass"
@@ -113,7 +109,7 @@ onUnmounted(() => {
     title="クリックで変換画像を保存します。"
   />
   <div
-    v-else-if="profile.settingList.tatie[tatieSituation].val === DEFAULT_KYARA_TATIE_UUID"
+    v-else-if="profile.tatie[tatieSituation].val === DEFAULT_KYARA_TATIE_UUID"
     :class="MakeClassString('flex items-center justify-center bg-sky-100', imgClass)"
   >
     未選択です

--- a/src/components/accessories/DisplayMoviePicFile.vue
+++ b/src/components/accessories/DisplayMoviePicFile.vue
@@ -97,7 +97,9 @@ const getKyaraImg = async (index?: number) => {
       index,
     )
     ChangeKyaraImg()
-  } else if (props.settype === 'tatieOrder') {
+  } else if (props.settype === 'tatieOrder' && props.tatieOrderList.length !== 0) {
+    // 立ち絵順序の設定の項目を表示しており、tatieOrderListに設定があれば実行
+
     // 二重起動しないように値を変更
     runMakeImg.value = false
 

--- a/src/components/accessories/DisplayMoviePicFile.vue
+++ b/src/components/accessories/DisplayMoviePicFile.vue
@@ -66,9 +66,24 @@ const ChangeKyaraImg = () => {
 }
 
 const getKyaraImg = async (index?: number) => {
-  const indexProfile = index !== undefined ? createVoiceFileEncodeSetting(index, props.dateList) : undefined
+  // indexが存在する値を示しているか確認します。
+  const ChkIndex = (): outSettingType | undefined => {
+    if (index === -1 || index === undefined || props.dateList[index] === undefined) {
+      return undefined
+    } else {
+      return createVoiceFileEncodeSetting(index, props.dateList)
+    }
+  }
+
+  // プロファイルを確認
+  const indexProfile = ChkIndex()
+
   // 立ち絵があり、他の画像取得が動作していない場合のみ実施
-  if (indexProfile?.tatie[props.tatieSituation].val !== DEFAULT_KYARA_TATIE_UUID && runMakeImg) {
+  if (
+    indexProfile !== undefined &&
+    indexProfile?.tatie[props.tatieSituation].val !== DEFAULT_KYARA_TATIE_UUID &&
+    runMakeImg
+  ) {
     // 二重起動しないように値を変更
     runMakeImg.value = false
 

--- a/src/components/accessories/DisplayMoviePicFile.vue
+++ b/src/components/accessories/DisplayMoviePicFile.vue
@@ -132,6 +132,12 @@ watch(
     @click="() => saveImg()"
     title="クリックで変換画像を保存します。"
   />
+  <div
+    v-else-if="profile?.tatie[tatieSituation].val === DEFAULT_KYARA_TATIE_UUID"
+    :class="MakeClassString('flex items-center justify-center bg-sky-100', imgClass)"
+  >
+    未選択です
+  </div>
   <div v-else-if="noTatieFile" :class="MakeClassString('flex items-center justify-center bg-sky-100', imgClass)">
     立ち絵ファイルが<br />見つかりませんでした
   </div>

--- a/src/components/accessories/DisplayMoviePicFile.vue
+++ b/src/components/accessories/DisplayMoviePicFile.vue
@@ -3,7 +3,7 @@ const props = withDefaults(
   defineProps<{
     dateList: outSettingType[]
     index: number
-    tatieSituation: 'tatieUUID' | 'waitTatieUUID'
+    tatieSituation: tatieSituationType
     infoData: infoSettingType
     imgClass?: string
   }>(),
@@ -11,7 +11,7 @@ const props = withDefaults(
 )
 // 立ち絵画像のみ変換を行って表示する
 
-import type { outSettingType, infoSettingType, encodeProfileSendReType } from '@/type/data-type'
+import type { outSettingType, infoSettingType, encodeProfileSendReType, tatieSituationType } from '@/type/data-type'
 import { ref, onUnmounted } from 'vue'
 import { enterEncodeTatiePicFile, enterSaveUint8ArrayFileData } from '@/utils/analysisFile'
 import { DEFAULT_KYARA_TATIE_UUID } from '@/data/data'

--- a/src/components/accessories/DisplayMoviePicFile.vue
+++ b/src/components/accessories/DisplayMoviePicFile.vue
@@ -8,6 +8,7 @@ const props = withDefaults(
     infoData: infoSettingType
     profile: outSettingType
     tatieOrderList: tatieOrderListType[]
+    isFileTatieOrderSetting: boolean
     imgClass?: string
   }>(),
   { tatieSituation: 'tatieUUID' },
@@ -97,8 +98,8 @@ const getKyaraImg = async (index?: number) => {
       index,
     )
     ChangeKyaraImg()
-  } else if (props.settype === 'tatieOrder' && props.tatieOrderList.length !== 0) {
-    // 立ち絵順序の設定の項目を表示しており、tatieOrderListに設定があれば実行
+  } else if ((props.settype === 'tatieOrder' || props.settype === 'seid') && props.tatieOrderList.length !== 0) {
+    // 立ち絵順序の設定の項目か音声ファイル個別の設定を表示しており、tatieOrderListに設定があれば実行
 
     // 二重起動しないように値を変更
     runMakeImg.value = false
@@ -112,6 +113,9 @@ const getKyaraImg = async (index?: number) => {
       props.tatieOrderList,
     )
     ChangeKyaraImg()
+  } else {
+    // 立ち絵が存在しない
+    noTatieFile.value = true
   }
 }
 
@@ -125,16 +129,22 @@ const saveImg = async () => {
   }
 }
 
+// 立ち絵サムネイルの変更処理を実行
+const EnterGetKyaraImg = () => {
+  if (props.settype === 'tatieOrder') {
+    getKyaraImg()
+  } else {
+    getKyaraImg(props.selectKyara)
+  }
+}
+
+// enterEncodeTatie を親コンポーネントから呼び出せるようにします
+defineExpose({ EnterGetKyaraImg })
+
 watch(
+  () => [props.profile, props.settype, props.tatieSituation, props.tatieOrderList, props.selectKyara],
   () => {
-    props.profile, props.settype, props.tatieSituation, props.tatieOrderList
-  },
-  () => {
-    if (props.settype === 'tatieOrder') {
-      getKyaraImg()
-    } else {
-      getKyaraImg(props.selectKyara)
-    }
+    EnterGetKyaraImg()
   },
   { deep: true },
 )
@@ -143,7 +153,9 @@ watch(
 <template>
   <img
     v-if="
-      (settype === 'tatieOrder' || profile?.tatie[tatieSituation].val !== DEFAULT_KYARA_TATIE_UUID) &&
+      (settype === 'tatieOrder' ||
+        settype === 'seid' ||
+        profile?.tatie[tatieSituation].val !== DEFAULT_KYARA_TATIE_UUID) &&
       typeof img === 'string' &&
       noTatieFile !== true
     "

--- a/src/components/accessories/DisplaySettingSampleView.vue
+++ b/src/components/accessories/DisplaySettingSampleView.vue
@@ -16,10 +16,9 @@ import type {
   tatieOrderListType,
   dataTextType,
 } from '@/type/data-type'
-import { SelectTatieIndexHigherUpData, createVoiceFileEncodeSetting } from '@/utils/analysisData'
-import { watch, onUnmounted, ref } from 'vue'
+import { createVoiceFileEncodeSetting } from '@/utils/analysisData'
+import { onUnmounted, ref } from 'vue'
 import DisplayMoviePicFile from '@/components/accessories/DisplayMoviePicFile.vue'
-import { DEFAULT_KYARA_TATIE_UUID } from '@/data/data'
 import { MakeClassString } from '@/utils/analysisGeneral'
 
 // 会話中・待機中のどちらの立ち絵を表示するか指定

--- a/src/components/accessories/DisplaySettingSampleView.vue
+++ b/src/components/accessories/DisplaySettingSampleView.vue
@@ -30,6 +30,15 @@ const profile = ref<outSettingType>(createVoiceFileEncodeSetting(props.selectKya
 // 設定変更の比較チェックのため、内容を文字列に変換して保存する変数
 const checkConf = ref<string>(JSON.stringify([profile.value?.tatie, tatieSituation], undefined, 2))
 
+// 立ち絵の表示を更新
+const enterEncodeTatie = () => {
+  profile.value = createVoiceFileEncodeSetting(props.selectKyara, props.dateList)
+  checkConf.value = JSON.stringify([profile.value?.tatie, tatieSituation], undefined, 2)
+}
+
+// enterEncodeTatie を親コンポーネントから呼び出せるようにします
+defineExpose({ enterEncodeTatie })
+
 // 指定時間ごとに確認し、立ち絵の設定が変わったら表示を変更する
 const onEncodeTatie = setInterval(() => {
   // キャラが未選択でなければ実行
@@ -43,8 +52,7 @@ const onEncodeTatie = setInterval(() => {
 
     // 比較して前回の内容と異なっていれば立ち絵画像の表示を更新する。
     if (checkConf.value !== ans) {
-      profile.value = createVoiceFileEncodeSetting(props.selectKyara, props.dateList)
-      checkConf.value = ans
+      enterEncodeTatie()
     }
   }
 }, 2000)

--- a/src/components/accessories/DisplaySettingSampleView.vue
+++ b/src/components/accessories/DisplaySettingSampleView.vue
@@ -1,14 +1,22 @@
 <script setup lang="ts">
 const props = defineProps<{
   dateList: outSettingType[]
+  settype: dataTextType
   higherUpList: [number, number]
   selectKyara: number
   infoData: infoSettingType
+  tatieOrderList: tatieOrderListType[]
   onSampleView: boolean // 立ち絵の加工と表示を行うか選択
 }>()
 // 立ち絵画像の加工を行って表示します。
 
-import type { outSettingType, infoSettingType, tatieSituationType } from '@/type/data-type'
+import type {
+  outSettingType,
+  infoSettingType,
+  tatieSituationType,
+  tatieOrderListType,
+  dataTextType,
+} from '@/type/data-type'
 import { SelectTatieIndexHigherUpData } from '@/utils/analysisData'
 import { watch, ref } from 'vue'
 import DisplayMoviePicFile from '@/components/accessories/DisplayMoviePicFile.vue'
@@ -21,7 +29,7 @@ const tatieSituation = ref<tatieSituationType>('tatieUUID')
 //// どの設定データが採用されているか確認する。
 // 立ち絵画像のUUID
 const selectTatiePicFile = (): string => {
-  if (props.onSampleView) {
+  if (props.dateList[props.selectKyara] !== undefined) {
     if (props.dateList[props.selectKyara].tatie[tatieSituation.value].active) {
       return props.dateList[props.selectKyara].tatie[tatieSituation.value].val
     } else {
@@ -49,7 +57,7 @@ watch(
 // 表示している設定が変更されたら立ち絵の画像も変更
 // キャラが選択されているか確認して、実行する。
 watch(
-  () => props.onSampleView && props.dateList[props.selectKyara].tatie[tatieSituation.value],
+  () => props.onSampleView && props.dateList[props.selectKyara]?.tatie[tatieSituation.value],
   () => {
     setTatiePicFile.value = selectTatiePicFile()
   },
@@ -87,12 +95,14 @@ watch(
     </div>
     <div
       class="h-36 w-full border-[1px] border-gray-400"
-      v-if="onSampleView && setTatiePicFile !== DEFAULT_KYARA_TATIE_UUID"
+      v-if="onSampleView || setTatiePicFile !== DEFAULT_KYARA_TATIE_UUID"
     >
       <DisplayMoviePicFile
         :dateList="dateList"
-        :index="selectKyara"
+        :settype="settype"
+        :selectKyara="selectKyara"
         :infoData="infoData"
+        :tatieOrderList="tatieOrderList"
         :tatieSituation="tatieSituation"
         imgClass="w-full h-full"
       />

--- a/src/components/accessories/DisplaySettingSampleView.vue
+++ b/src/components/accessories/DisplaySettingSampleView.vue
@@ -13,16 +13,20 @@ import { SelectTatieIndexHigherUpData } from '@/utils/analysisData'
 import { watch, ref } from 'vue'
 import DisplayMoviePicFile from '@/components/accessories/DisplayMoviePicFile.vue'
 import { DEFAULT_KYARA_TATIE_UUID } from '@/data/data'
+import { MakeClassString } from '@/utils/analysisGeneral'
+
+// 会話中・待機中のどちらの立ち絵を表示するか指定
+const tatieSituation = ref<'tatieUUID' | 'waitTatieUUID'>('tatieUUID')
 
 //// どの設定データが採用されているか確認する。
 // 立ち絵画像のUUID
 const selectTatiePicFile = (): string => {
   if (props.onSampleView) {
-    if (props.dateList[props.selectKyara].tatie.tatieUUID.active) {
-      return props.dateList[props.selectKyara].tatie.tatieUUID.val
+    if (props.dateList[props.selectKyara].tatie[tatieSituation.value].active) {
+      return props.dateList[props.selectKyara].tatie[tatieSituation.value].val
     } else {
-      return props.dateList[SelectTatieIndexHigherUpData(props.higherUpList, props.dateList, 'tatieUUID')].tatie
-        .tatieUUID.val
+      return props.dateList[SelectTatieIndexHigherUpData(props.higherUpList, props.dateList, tatieSituation.value)]
+        .tatie[tatieSituation.value].val
     }
   } else {
     return DEFAULT_KYARA_TATIE_UUID
@@ -34,7 +38,9 @@ const setTatiePicFile = ref<string>(selectTatiePicFile())
 
 // 選択しているキャラ設定が変更されたら変更する
 watch(
-  () => props.selectKyara,
+  () => {
+    props.selectKyara, tatieSituation.value
+  },
   () => {
     setTatiePicFile.value = selectTatiePicFile()
   },
@@ -43,7 +49,7 @@ watch(
 // 表示している設定が変更されたら立ち絵の画像も変更
 // キャラが選択されているか確認して、実行する。
 watch(
-  () => props.onSampleView && props.dateList[props.selectKyara].tatie.tatieUUID,
+  () => props.onSampleView && props.dateList[props.selectKyara].tatie[tatieSituation.value],
   () => {
     setTatiePicFile.value = selectTatiePicFile()
   },
@@ -52,11 +58,45 @@ watch(
 </script>
 
 <template>
-  <div
-    class="relative h-36 w-full border-[1px] border-gray-400"
-    v-if="onSampleView && setTatiePicFile !== DEFAULT_KYARA_TATIE_UUID"
-  >
-    <DisplayMoviePicFile :dateList="dateList" :index="selectKyara" :infoData="infoData" imgClass="w-full h-full" />
+  <div class="flex items-start">
+    <div class="flex w-6 flex-col text-center text-sm">
+      <button
+        :class="
+          MakeClassString(
+            'rounded-tl-lg border-[1px] border-gray-300',
+            tatieSituation === 'tatieUUID' ? 'bg-sky-400' : 'bg-gray-200',
+          )
+        "
+        title="会話中の立ち絵を表示します"
+        @click="() => (tatieSituation = 'tatieUUID')"
+      >
+        会話中
+      </button>
+      <button
+        :class="
+          MakeClassString(
+            'rounded-bl-lg border-[1px] border-gray-300',
+            tatieSituation === 'waitTatieUUID' ? 'bg-sky-400' : 'bg-gray-200',
+          )
+        "
+        title="待機中の立ち絵を表示します"
+        @click="() => (tatieSituation = 'waitTatieUUID')"
+      >
+        待機中
+      </button>
+    </div>
+    <div
+      class="h-36 w-full border-[1px] border-gray-400"
+      v-if="onSampleView && setTatiePicFile !== DEFAULT_KYARA_TATIE_UUID"
+    >
+      <DisplayMoviePicFile
+        :dateList="dateList"
+        :index="selectKyara"
+        :infoData="infoData"
+        :tatieSituation="tatieSituation"
+        imgClass="w-full h-full"
+      />
+    </div>
+    <div v-else class="flex h-36 w-full items-center justify-center border-[1px] border-gray-400 p-1">未選択です</div>
   </div>
-  <div v-else class="flex h-36 w-full items-center justify-center border-[1px] border-gray-400 p-1">未選択です</div>
 </template>

--- a/src/components/accessories/DisplaySettingSampleView.vue
+++ b/src/components/accessories/DisplaySettingSampleView.vue
@@ -25,24 +25,6 @@ import { MakeClassString } from '@/utils/analysisGeneral'
 // 会話中・待機中のどちらの立ち絵を表示するか指定
 const tatieSituation = ref<tatieSituationType>('tatieUUID')
 
-//// どの設定データが採用されているか確認する。
-// 立ち絵画像のUUID
-const selectTatiePicFile = (): string => {
-  if (props.dateList[props.selectKyara] !== undefined) {
-    if (props.dateList[props.selectKyara].tatie[tatieSituation.value].active) {
-      return props.dateList[props.selectKyara].tatie[tatieSituation.value].val
-    } else {
-      return props.dateList[SelectTatieIndexHigherUpData(props.higherUpList, props.dateList, tatieSituation.value)]
-        .tatie[tatieSituation.value].val
-    }
-  } else {
-    return DEFAULT_KYARA_TATIE_UUID
-  }
-}
-
-// 設定によって立ち絵画像のUUIDを変更する
-const setTatiePicFile = ref<string>(selectTatiePicFile())
-
 ////  コンポーネント表示時に、立ち絵画像の表示をも行う
 // 表示するプロファイル情報
 const profile = ref<outSettingType>(createVoiceFileEncodeSetting(props.selectKyara, props.dateList))
@@ -64,26 +46,6 @@ const onEncodeTatie = setInterval(() => {
     checkConf.value = ans
   }
 }, 2000)
-
-// 選択しているキャラ設定が変更されたら変更する
-watch(
-  () => {
-    props.selectKyara, tatieSituation.value
-  },
-  () => {
-    setTatiePicFile.value = selectTatiePicFile()
-  },
-)
-
-// 表示している設定が変更されたら立ち絵の画像も変更
-// キャラが選択されているか確認して、実行する。
-watch(
-  () => setTatiePicFile.value && props.dateList[props.selectKyara]?.tatie[tatieSituation.value],
-  () => {
-    setTatiePicFile.value = selectTatiePicFile()
-  },
-  { deep: true },
-)
 
 // コンポーネントが表示されなくなったらsetIntervalを停止
 onUnmounted(() => {
@@ -119,7 +81,7 @@ onUnmounted(() => {
         待機中
       </button>
     </div>
-    <div class="h-36 w-full border-[1px] border-gray-400" v-if="setTatiePicFile !== DEFAULT_KYARA_TATIE_UUID">
+    <div class="h-36 w-full border-[1px] border-gray-400">
       <DisplayMoviePicFile
         :dateList="dateList"
         :settype="settype"
@@ -131,6 +93,5 @@ onUnmounted(() => {
         imgClass="w-full h-full"
       />
     </div>
-    <div v-else class="flex h-36 w-full items-center justify-center border-[1px] border-gray-400 p-1">未選択です</div>
   </div>
 </template>

--- a/src/components/accessories/DisplaySettingSampleView.vue
+++ b/src/components/accessories/DisplaySettingSampleView.vue
@@ -32,17 +32,20 @@ const checkConf = ref<string>(JSON.stringify([profile.value?.tatie, tatieSituati
 
 // 指定時間ごとに確認し、立ち絵の設定が変わったら表示を変更する
 const onEncodeTatie = setInterval(() => {
-  // 比較のために設定内容をJSON形式に変換
-  const ans = JSON.stringify(
-    [createVoiceFileEncodeSetting(props.selectKyara, props.dateList)?.tatie, tatieSituation],
-    undefined,
-    2,
-  )
+  // キャラが未選択でなければ実行
+  if (props.selectKyara !== -1) {
+    // 比較のために設定内容をJSON形式に変換
+    const ans = JSON.stringify(
+      [createVoiceFileEncodeSetting(props.selectKyara, props.dateList)?.tatie, tatieSituation],
+      undefined,
+      2,
+    )
 
-  // 比較して前回の内容と異なっていれば立ち絵画像の表示を更新する。
-  if (checkConf.value !== ans) {
-    profile.value = createVoiceFileEncodeSetting(props.selectKyara, props.dateList)
-    checkConf.value = ans
+    // 比較して前回の内容と異なっていれば立ち絵画像の表示を更新する。
+    if (checkConf.value !== ans) {
+      profile.value = createVoiceFileEncodeSetting(props.selectKyara, props.dateList)
+      checkConf.value = ans
+    }
   }
 }, 2000)
 

--- a/src/components/accessories/DisplaySettingSampleView.vue
+++ b/src/components/accessories/DisplaySettingSampleView.vue
@@ -8,7 +8,7 @@ const props = defineProps<{
 }>()
 // 立ち絵画像の加工を行って表示します。
 
-import type { outSettingType, infoSettingType } from '@/type/data-type'
+import type { outSettingType, infoSettingType, tatieSituationType } from '@/type/data-type'
 import { SelectTatieIndexHigherUpData } from '@/utils/analysisData'
 import { watch, ref } from 'vue'
 import DisplayMoviePicFile from '@/components/accessories/DisplayMoviePicFile.vue'
@@ -16,7 +16,7 @@ import { DEFAULT_KYARA_TATIE_UUID } from '@/data/data'
 import { MakeClassString } from '@/utils/analysisGeneral'
 
 // 会話中・待機中のどちらの立ち絵を表示するか指定
-const tatieSituation = ref<'tatieUUID' | 'waitTatieUUID'>('tatieUUID')
+const tatieSituation = ref<tatieSituationType>('tatieUUID')
 
 //// どの設定データが採用されているか確認する。
 // 立ち絵画像のUUID

--- a/src/components/accessories/DisplaySettingSampleView.vue
+++ b/src/components/accessories/DisplaySettingSampleView.vue
@@ -6,6 +6,7 @@ const props = defineProps<{
   selectKyara: number
   infoData: infoSettingType
   tatieOrderList: tatieOrderListType[]
+  isFileTatieOrderSetting: boolean
 }>()
 // 立ち絵画像の加工を行って表示します。
 
@@ -24,16 +25,21 @@ import { MakeClassString } from '@/utils/analysisGeneral'
 // 会話中・待機中のどちらの立ち絵を表示するか指定
 const tatieSituation = ref<tatieSituationType>('tatieUUID')
 
+const refDisplayMoviePicFile = ref<InstanceType<typeof DisplayMoviePicFile> | null>(null)
+
 ////  コンポーネント表示時に、立ち絵画像の表示をも行う
 // 表示するプロファイル情報
 const profile = ref<outSettingType>(createVoiceFileEncodeSetting(props.selectKyara, props.dateList))
 // 設定変更の比較チェックのため、内容を文字列に変換して保存する変数
-const checkConf = ref<string>(JSON.stringify([profile.value?.tatie, tatieSituation], undefined, 2))
+const checkConf = ref<string>(
+  JSON.stringify([profile.value?.tatie, tatieSituation, props.tatieOrderList], undefined, 2),
+)
 
 // 立ち絵の表示を更新
 const enterEncodeTatie = () => {
   profile.value = createVoiceFileEncodeSetting(props.selectKyara, props.dateList)
-  checkConf.value = JSON.stringify([profile.value?.tatie, tatieSituation], undefined, 2)
+  refDisplayMoviePicFile.value.EnterGetKyaraImg()
+  checkConf.value = JSON.stringify([profile.value?.tatie, tatieSituation, props.tatieOrderList], undefined, 2)
 }
 
 // enterEncodeTatie を親コンポーネントから呼び出せるようにします
@@ -45,7 +51,7 @@ const onEncodeTatie = setInterval(() => {
   if (props.selectKyara !== -1) {
     // 比較のために設定内容をJSON形式に変換
     const ans = JSON.stringify(
-      [createVoiceFileEncodeSetting(props.selectKyara, props.dateList)?.tatie, tatieSituation],
+      [createVoiceFileEncodeSetting(props.selectKyara, props.dateList)?.tatie, tatieSituation, props.tatieOrderList],
       undefined,
       2,
     )
@@ -103,7 +109,9 @@ onUnmounted(() => {
         :profile="profile"
         :tatieOrderList="tatieOrderList"
         :tatieSituation="tatieSituation"
+        :isFileTatieOrderSetting="isFileTatieOrderSetting"
         imgClass="w-full h-full"
+        ref="refDisplayMoviePicFile"
       />
     </div>
   </div>

--- a/src/components/accessories/DisplaySettingSampleView.vue
+++ b/src/components/accessories/DisplaySettingSampleView.vue
@@ -65,7 +65,7 @@ onUnmounted(() => {
 
 <template>
   <div class="flex items-start">
-    <div class="flex w-6 flex-col text-center text-sm">
+    <div class="flex w-6 flex-col text-center text-sm" v-if="settype !== 'tatieOrder'">
       <button
         :class="
           MakeClassString(
@@ -90,6 +90,9 @@ onUnmounted(() => {
       >
         待機中
       </button>
+    </div>
+    <div class="flex w-6 flex-col text-center text-sm" v-else>
+      <div class="rounded-l-lg border-[1px] border-gray-300 bg-sky-400">待機中</div>
     </div>
     <div class="h-36 w-full border-[1px] border-gray-400">
       <DisplayMoviePicFile

--- a/src/components/accessories/DisplaySettingSampleView.vue
+++ b/src/components/accessories/DisplaySettingSampleView.vue
@@ -6,7 +6,6 @@ const props = defineProps<{
   selectKyara: number
   infoData: infoSettingType
   tatieOrderList: tatieOrderListType[]
-  onSampleView: boolean // 立ち絵の加工と表示を行うか選択
 }>()
 // 立ち絵画像の加工を行って表示します。
 
@@ -57,7 +56,7 @@ watch(
 // 表示している設定が変更されたら立ち絵の画像も変更
 // キャラが選択されているか確認して、実行する。
 watch(
-  () => props.onSampleView && props.dateList[props.selectKyara]?.tatie[tatieSituation.value],
+  () => setTatiePicFile.value && props.dateList[props.selectKyara]?.tatie[tatieSituation.value],
   () => {
     setTatiePicFile.value = selectTatiePicFile()
   },
@@ -95,7 +94,7 @@ watch(
     </div>
     <div
       class="h-36 w-full border-[1px] border-gray-400"
-      v-if="onSampleView || setTatiePicFile !== DEFAULT_KYARA_TATIE_UUID"
+      v-if="setTatiePicFile !== DEFAULT_KYARA_TATIE_UUID"
     >
       <DisplayMoviePicFile
         :dateList="dateList"

--- a/src/components/accessories/EditDisplayTatiePicPathKyaraData.vue
+++ b/src/components/accessories/EditDisplayTatiePicPathKyaraData.vue
@@ -9,7 +9,7 @@ const props = defineProps<{
   titleName: string
   fileListTatie: fileListTatieType[]
 }>()
-import type { dataTextType, outSettingType, fileListTatieType } from 'src/type/data-type'
+import type { dataTextType, outSettingType, fileListTatieType, tatieSituationType } from 'src/type/data-type'
 import { SelectTatieIndexHigherUpData } from '@/utils/analysisData'
 import { ref, watch } from 'vue'
 import deleteDialogUUID from '@/components/accessories/deleteDialogUUID.vue'
@@ -22,7 +22,7 @@ import { MakeClassString } from '@/utils/analysisGeneral'
 const { yomAPI } = window
 
 const isOpenTatieFile = ref<boolean>(false)
-const editTatieType = ref<'tatieUUID' | 'waitTatieUUID'>('tatieUUID') // どの立ち絵を変更するか指定
+const editTatieType = ref<tatieSituationType>('tatieUUID') // どの立ち絵を変更するか指定
 
 const tatieFileRef = ref()
 
@@ -43,7 +43,7 @@ const viewFileListTatie = ref<fileListTatieType[]>(
 )
 
 // 選択画面の開閉を制御
-const setIsOpenTatieFile = (type?: 'tatieUUID' | 'waitTatieUUID'): void => {
+const setIsOpenTatieFile = (type?: tatieSituationType): void => {
   isOpenTatieFile.value = !isOpenTatieFile.value
   if (type !== undefined) {
     editTatieType.value = type

--- a/src/components/accessories/EditDisplayTatiePicPathKyaraData.vue
+++ b/src/components/accessories/EditDisplayTatiePicPathKyaraData.vue
@@ -248,7 +248,6 @@ watch(
           @click="setIsOpenTatieFile('waitTatieUUID')"
           :title="'待機立ち絵: ' + useTatieName()"
           :disabled="!dateList[selectKyara].tatie.waitTatieUUID.active"
-          v-if="props.settype !== 'seid'"
         >
           <DisplayTatiePicFile
             :selectTatieFile="

--- a/src/components/accessories/EditDisplayTatiePicPathKyaraData.vue
+++ b/src/components/accessories/EditDisplayTatiePicPathKyaraData.vue
@@ -18,9 +18,11 @@ import SelectDisplayHigherUpStatus from '@/components/accessories/SelectDisplayH
 import SelectDisplayTatieFile from '@/components/accessories/SelectDisplayTatieFile.vue'
 import { DEFAULT_KYARA_TATIE_UUID } from '@/data/data'
 import DisplayTatiePicFile from '@/components/accessories/DisplayTatiePicFile.vue'
+import { MakeClassString } from '@/utils/analysisGeneral'
 const { yomAPI } = window
 
 const isOpenTatieFile = ref<boolean>(false)
+const editTatieType = ref<'tatieUUID' | 'waitTatieUUID'>('tatieUUID') // どの立ち絵を変更するか指定
 
 const tatieFileRef = ref()
 
@@ -41,8 +43,11 @@ const viewFileListTatie = ref<fileListTatieType[]>(
 )
 
 // 選択画面の開閉を制御
-const setIsOpenTatieFile = (): void => {
+const setIsOpenTatieFile = (type?: 'tatieUUID' | 'waitTatieUUID'): void => {
   isOpenTatieFile.value = !isOpenTatieFile.value
+  if (type !== undefined) {
+    editTatieType.value = type
+  }
 }
 
 // どの上位設定を使うか決定する
@@ -56,9 +61,9 @@ const clickEdit = (newFileName: string, index?: number) => {
   console.log('clickEdit変更処理: ' + newFileName)
   console.log('clickEdit変更処理実行: ' + newFileName)
   if (index !== undefined) {
-    props.dateList[index].tatie.tatieUUID.val = newFileName
+    props.dateList[index].tatie[editTatieType.value].val = newFileName
   } else {
-    props.dateList[props.selectKyara].tatie.tatieUUID.val = newFileName
+    props.dateList[props.selectKyara].tatie[editTatieType.value].val = newFileName
   }
 }
 
@@ -181,14 +186,6 @@ const FindFileListKyaraName = (): string | undefined => {
   }
 }
 
-// 状態によってボタンのTailwindを変更
-const actset = (): string => {
-  const setAns = props.dateList[props.selectKyara].tatie.tatieUUID.active
-    ? 'hover:bg-blue-600 hover:text-gray-200'
-    : 'text-gray-600'
-  return 'h-full truncate border border-gray-800 bg-blue-300 px-1' + ' ' + setAns
-}
-
 watch(
   () => props.higherUpList,
   () => {
@@ -199,15 +196,20 @@ watch(
 
 <template>
   <div class="flex border-b-[1px] border-gray-400 py-2">
-    <div class="mr-2 flex w-full justify-between">
-      <!-- 
+    <!-- 
           ここの設定を使用する場合に入力できる。
           上位設定を使用する場合は表示のみ。
          -->
-      <div class="w-2/3">
+    <div class="flex">
+      <div class="ml-2 flex">
         <button
-          :class="actset()"
-          @click="setIsOpenTatieFile"
+          :class="
+            MakeClassString(
+              'ml-2 h-full truncate border border-gray-800 bg-blue-300 px-1',
+              dateList[selectKyara].tatie.tatieUUID.active ? 'hover:bg-blue-600 hover:text-gray-200' : 'text-gray-600',
+            )
+          "
+          @click="setIsOpenTatieFile('tatieUUID')"
           :title="'立ち絵: ' + useTatieName()"
           :disabled="!dateList[selectKyara].tatie.tatieUUID.active"
         >
@@ -221,33 +223,69 @@ watch(
             personOffClass="h-12 w-12"
           />
         </button>
-        <div class="relative" v-if="isOpenTatieFile">
-          <SelectDisplayTatieFile
-            :clickClose="setIsOpenTatieFile"
-            :selectTatieFile="dateList[selectKyara].tatie.tatieUUID.val"
-            :clickEdit="clickEdit"
-            :fileListTatie="fileListTatie"
-            :defoTatie="defoTatie"
-            :editKyaraPicFile="editKyaraPicFile"
-            :deleteKyaraPicFile="askDeleteKyaraPic"
-            :importKyaraPicFile="importKyaraPicFile"
-            :viewFileListTatie="viewFileListTatie"
-            :selectKyaraName="FindFileListKyaraName()"
-            ref="tatieFileRef"
+        <SelectDisplayHigherUpStatus
+          class="flex h-full items-center"
+          :settype="props.settype"
+          :actStatus="dateList[selectKyara].tatie[tatieSetting].active"
+          :higherUpType="dateList[higherUpEditKyara].dataType"
+          :onClick="
+            () =>
+              (props.dateList[props.selectKyara].tatie[props.tatieSetting].active =
+                !props.dateList[props.selectKyara].tatie[props.tatieSetting].active)
+          "
+        />
+      </div>
+      <div class="ml-5 flex">
+        <button
+          :class="
+            MakeClassString(
+              'ml-2 h-full truncate border border-gray-800 bg-blue-300 px-1',
+              dateList[selectKyara].tatie.waitTatieUUID.active
+                ? 'hover:bg-blue-600 hover:text-gray-200'
+                : 'text-gray-600',
+            )
+          "
+          @click="setIsOpenTatieFile('waitTatieUUID')"
+          :title="'待機立ち絵: ' + useTatieName()"
+          :disabled="!dateList[selectKyara].tatie.waitTatieUUID.active"
+          v-if="props.settype !== 'seid'"
+        >
+          <DisplayTatiePicFile
+            :selectTatieFile="
+              dateList[selectKyara].tatie.waitTatieUUID.active
+                ? dateList[selectKyara].tatie.waitTatieUUID.val
+                : dateList[higherUpEditKyara].tatie.waitTatieUUID.val
+            "
+            imgClass="h-16"
+            personOffClass="h-12 w-12"
           />
-        </div>
+        </button>
+        <SelectDisplayHigherUpStatus
+          class="flex h-full items-center"
+          :settype="props.settype"
+          :actStatus="dateList[selectKyara].tatie.waitTatieUUID.active"
+          :higherUpType="dateList[higherUpEditKyara].dataType"
+          :onClick="
+            () =>
+              (props.dateList[props.selectKyara].tatie.waitTatieUUID.active =
+                !props.dateList[props.selectKyara].tatie.waitTatieUUID.active)
+          "
+        />
       </div>
     </div>
-    <div class="flex flex-col justify-center">
-      <SelectDisplayHigherUpStatus
-        :settype="props.settype"
-        :actStatus="dateList[selectKyara].tatie[tatieSetting].active"
-        :higherUpType="dateList[higherUpEditKyara].dataType"
-        :onClick="
-          () =>
-            (props.dateList[props.selectKyara].tatie[props.tatieSetting].active =
-              !props.dateList[props.selectKyara].tatie[props.tatieSetting].active)
-        "
+    <div class="relative" v-if="isOpenTatieFile">
+      <SelectDisplayTatieFile
+        :clickClose="setIsOpenTatieFile"
+        :selectTatieFile="dateList[selectKyara].tatie[editTatieType].val"
+        :clickEdit="clickEdit"
+        :fileListTatie="fileListTatie"
+        :defoTatie="defoTatie"
+        :editKyaraPicFile="editKyaraPicFile"
+        :deleteKyaraPicFile="askDeleteKyaraPic"
+        :importKyaraPicFile="importKyaraPicFile"
+        :viewFileListTatie="viewFileListTatie"
+        :selectKyaraName="FindFileListKyaraName()"
+        ref="tatieFileRef"
       />
     </div>
   </div>

--- a/src/components/accessories/SelectDisplayHigherUpStatus.vue
+++ b/src/components/accessories/SelectDisplayHigherUpStatus.vue
@@ -7,29 +7,28 @@ const props = defineProps<{
 }>()
 
 // 選択中のキャラ設定で、その項目を有効にするか選択するボタン
+// ONのときはそのキャラ設定タイプ
 // OFFのときはどの上位設定が使われているか色で表示する。
 
 import type { dataTextType } from '@/type/data-type'
 import { typeColor } from '@/data/data'
-
-// ボタンの色を決める
-// ONのときはそのキャラ設定タイプ
-// OFFのときは使用する上位設定の色にする
-const selectTypeColor = (): string => {
-  return props.actStatus
-    ? typeColor[props.settype].bg + ' ' + 'border-gray-800'
-    : typeColor[props.higherUpType].bg + ' ' + 'text-gray-500 border-gray-500'
-}
-
-// 選択中の要素の場合は背景色を変更する
-const actset = (): string => {
-  return 'px-1 border rounded-full w-10 font-medium hover:bg-gray-600 hover:text-gray-100' + ' ' + selectTypeColor()
-}
+import { MakeClassString } from '@/utils/analysisGeneral'
 </script>
 
 <template>
   <div v-if="settype !== 'defo'" class="flex w-14 justify-end border-l-[1px] border-gray-400" title="ここの設定を使用">
-    <button @click="onClick()" :class="actset()" :title="actStatus ? 'この設定を使用' : '上位設定を使用'">
+    <button
+      @click="onClick()"
+      :class="
+        MakeClassString(
+          'w-10 rounded-full border px-1 font-medium hover:bg-gray-600 hover:text-gray-100',
+          actStatus
+            ? typeColor[props.settype].bg + ' ' + 'border-gray-800'
+            : typeColor[props.higherUpType].bg + ' ' + 'border-gray-500 text-gray-500',
+        )
+      "
+      :title="actStatus ? 'この設定を使用' : '上位設定を使用'"
+    >
       {{ actStatus ? 'ON' : 'OFF' }}
     </button>
   </div>

--- a/src/components/accessories/SelectDisplayKyaraRightClickMenu.vue
+++ b/src/components/accessories/SelectDisplayKyaraRightClickMenu.vue
@@ -4,9 +4,11 @@ const props = defineProps<{
   CopyKyaraSetting: (settype: dataTextType) => void
   editDataClik: () => void
   askDeleteKyara: () => void
+  checkIntoTatieOrderList: () => boolean
 }>()
 // キャラ設定のコピーや削除の選択を行う右クリックメニュー
 import { dataTextType } from '@/type/data-type'
+import { MakeClassString } from '@/utils/analysisGeneral'
 </script>
 
 <template>
@@ -43,7 +45,16 @@ import { dataTextType } from '@/type/data-type'
     </button>
     <button
       @click="askDeleteKyara()"
-      class="flex justify-between bg-blue-100 px-2 py-1 text-gray-700 hover:bg-blue-600 hover:text-gray-200"
+      :class="
+        MakeClassString(
+          'flex justify-between px-2 py-1',
+          checkIntoTatieOrderList()
+            ? 'bg-gray-200 text-gray-500'
+            : 'bg-blue-100 text-gray-700 hover:bg-blue-600 hover:text-gray-200',
+        )
+      "
+      :title="checkIntoTatieOrderList() ? 'プロファイルの「立ち絵順序の設定」に入っている場合は削除できません。' : ''"
+      :disabled="checkIntoTatieOrderList()"
     >
       <div>削除</div>
       <div>Ctrl+D</div>

--- a/src/components/accessories/SelectDisplayTatieFile.vue
+++ b/src/components/accessories/SelectDisplayTatieFile.vue
@@ -78,7 +78,7 @@ watch(
 </script>
 
 <template>
-  <div class="fixed right-0 top-0 flex h-screen w-screen items-center justify-center" @click.self="clickClose">
+  <div class="fixed right-0 top-0 flex h-screen w-screen items-center justify-center" @click.self="clickClose()">
     <!-- 画面外クリックでクローズ -->
   </div>
   <div class="absolute flex h-96 border border-gray-700 bg-gray-300">

--- a/src/components/accessories/SelectDisplayTatieOrderKyara.vue
+++ b/src/components/accessories/SelectDisplayTatieOrderKyara.vue
@@ -2,10 +2,13 @@
 const props = defineProps<{
   clickClose: () => void
   TatieOrderChange: (uuid: string, outSetting: outSettingType) => void
+  settype: dataTextType
   dateList: outSettingType[]
   selectTatieOrderListUUID: string
   selectDataType: dataTextType
   selectKyaraName: string
+  subTextStringList: { [key: string]: { val: string; active: boolean } }
+  useSubText: boolean
   selectKyaraStyle?: string
 }>()
 // 複数の立ち絵の表示順番を設定する画面で、キャラ設定の選択を行う画面
@@ -25,6 +28,7 @@ const refSearchString = ref<{ searchString: string }>({ searchString: undefined 
 const kyaraProfileList = props.dateList
   .filter((e) => e.dataType === 'defo' || e.dataType === 'kyara')
   .concat(props.dateList.filter((e) => e.dataType === 'kyast'))
+  .concat(props.settype === 'seid' ? props.dateList.filter((e) => e.dataType === 'seid') : [])
 
 // キャラの変更と選択画面のcloseを行う
 const KyaraChange = (outSetting: outSettingType): void => {
@@ -49,13 +53,31 @@ const KyaraChange = (outSetting: outSettingType): void => {
                 typeColor[item.dataType].bg,
               )
             "
-            :title="item.name + (item.dataType === 'kyast' ? '（' + item.kyaraStyle + '）' : '')"
+            :title="
+              item.name +
+              (item.dataType === 'kyast'
+                ? '（' + item.kyaraStyle + '）'
+                : item.dataType === 'seid'
+                  ? '：' +
+                    (subTextStringList[item.uuid].active
+                      ? subTextStringList[item.uuid].val
+                      : item.fileName + '.' + item.fileExtension)
+                  : '')
+            "
             v-if="FindAllString(refSearchString.searchString, [item.kyaraStyle, item.name])"
             @click="() => KyaraChange(item)"
           >
             <div class="max-w-60 truncate">{{ item.name }}</div>
             <div class="max-w-48 truncate" v-if="item.dataType === 'kyast'">
               {{ '（' + item.kyaraStyle + '）' }}
+            </div>
+            <div class="max-w-48 truncate" v-else-if="item.dataType === 'seid' && subTextStringList[item.uuid].active">
+              {{
+                '：' +
+                (subTextStringList[item.uuid].active
+                  ? subTextStringList[item.uuid].val
+                  : item.fileName + '.' + item.fileExtension)
+              }}
             </div>
           </button>
         </div>

--- a/src/components/accessories/SelectDisplayTatieOrderKyara.vue
+++ b/src/components/accessories/SelectDisplayTatieOrderKyara.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+const props = defineProps<{
+  clickClose: () => void
+  TatieOrderChange: (uuid: string, outSetting: outSettingType) => void
+  dateList: outSettingType[]
+  selectTatieOrderListUUID: string
+  selectDataType: dataTextType
+  selectKyaraName: string
+  selectKyaraStyle?: string
+}>()
+// 複数の立ち絵の表示順番を設定する画面で、キャラ設定の選択を行う画面
+
+import { ref } from 'vue'
+import type { outSettingType, dataTextType } from 'src/type/data-type'
+import { typeColor } from '@/data/data'
+import { MakeClassString } from '@/utils/analysisGeneral'
+import { FindAllString } from '@/utils/analysisData'
+import SearchInputUnit from '@/components/unit/SearchInputUnit.vue'
+
+// 検索用
+const refSearchString = ref<{ searchString: string }>({ searchString: undefined })
+
+// キャラ設定からseid以外を抽出する。
+// defo, kyara, kyast の順で記録する。
+const kyaraProfileList = props.dateList
+  .filter((e) => e.dataType === 'defo' || e.dataType === 'kyara')
+  .concat(props.dateList.filter((e) => e.dataType === 'kyast'))
+
+// キャラの変更と選択画面のcloseを行う
+const KyaraChange = (outSetting: outSettingType): void => {
+  props.TatieOrderChange(props.selectTatieOrderListUUID, outSetting)
+  props.clickClose()
+}
+</script>
+
+<template>
+  <div class="fixed right-0 top-0 flex h-screen w-screen items-center justify-center" @click.self="clickClose()">
+    <!-- 画面外クリックでクローズ -->
+  </div>
+  <div class="border-1 fixed top-1/3 flex w-96 flex-col rounded-xl border-gray-800 bg-blue-100 px-5 py-4 text-sm">
+    <div class="h-80 overflow-y-scroll border border-gray-600">
+      <SearchInputUnit classSetting="bg-gray-300" inputTitle="立ち絵名かキャラ名で検索" ref="refSearchString" />
+      <div class="">
+        <div v-for="item in kyaraProfileList" v-bind:key="item.uuid">
+          <button
+            :class="
+              MakeClassString(
+                'my-1 ml-1 flex w-11/12 items-center rounded-3xl border border-black px-2 text-lg',
+                typeColor[item.dataType].bg,
+              )
+            "
+            :title="item.name + (item.dataType === 'kyast' ? '（' + item.kyaraStyle + '）' : '')"
+            v-if="FindAllString(refSearchString.searchString, [item.kyaraStyle, item.name])"
+            @click="() => KyaraChange(item)"
+          >
+            <div class="max-w-60 truncate">{{ item.name }}</div>
+            <div class="max-w-48 truncate" v-if="item.dataType === 'kyast'">
+              {{ '（' + item.kyaraStyle + '）' }}
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/makeComList.vue
+++ b/src/components/makeComList.vue
@@ -605,7 +605,7 @@ watch(
 
 // 設定に編集があったときにはtrueを入れる
 watch(
-  () => dateList.value,
+  () => (dateList.value, infoData.value, tatieOrderList.value),
   () => {
     props.setChangeDataSettingSta(true)
   },

--- a/src/components/makeComList.vue
+++ b/src/components/makeComList.vue
@@ -356,7 +356,8 @@ const entOpen = (): void => {
 const encodeAndDisplay = async (index: number): Promise<void> => {
   await enterEncodeVideoFile(
     voiceLoadDirPath.value,
-    createVoiceFileEncodeSetting(dateList.value[index], index, dateList.value, infoData.value),
+    createVoiceFileEncodeSetting(index, dateList.value),
+    infoData.value,
   )
   encodeAns.value = 'エンコード完了: ' + dateList.value[index].fileName
 }

--- a/src/components/makeComList.vue
+++ b/src/components/makeComList.vue
@@ -476,6 +476,24 @@ const TatieOrderAdd = (outSettingTtems: outSettingType[]) => {
   }
 }
 
+// tatieOrderListに表示する立ち絵を、選択されたキャラに変更する。
+const TatieOrderChange = (uuid: string, outSetting: outSettingType) => {
+  const changeItemindex = tatieOrderList.value.findIndex((e) => e.uuid === uuid)
+
+  // 値が見つかったら変更
+  if (changeItemindex !== -1) {
+    tatieOrderList.value[changeItemindex] = {
+      uuid: uuid,
+      dataType: outSetting.dataType,
+      name: outSetting.name,
+      kyaraStyle: outSetting.dataType === 'kyast' ? outSetting.kyaraStyle : undefined,
+      tatieSituation: outSetting.tatie.waitTatieUUID.active ? 'waitTatieUUID' : 'tatieUUID',
+    }
+  }
+  // 立ち絵の変換サンプルを更新
+  refEnterEncodeTatie.value?.enterEncodeTatie()
+}
+
 // tatieOrderListに表示する立ち絵を削除する。
 const TatieOrderDel = (index: number) => {
   tatieOrderList.value.splice(index, 1)

--- a/src/components/makeComList.vue
+++ b/src/components/makeComList.vue
@@ -117,6 +117,8 @@ const setKyaraListRef = ref(null)
 // 移動開始時の数値を保存する変数
 const dragStartIndex = ref<number>()
 
+const refEnterEncodeTatie = ref<InstanceType<typeof DisplaySettingSampleView> | null>(null)
+
 // エンコードダイアログを閉じる
 const closeEncodeDialog = (): void => {
   isEncodeOpen.value = false
@@ -432,6 +434,8 @@ const TatieOrderDragMove = (index: number) => {
     const moveItem = tatieOrderList.value.splice(dragStartIndex.value, 1)[0]
     tatieOrderList.value.splice(index, 0, moveItem)
     dragStartIndex.value = index
+    // 立ち絵の変換サンプルを更新
+    refEnterEncodeTatie.value?.enterEncodeTatie()
   }
 }
 
@@ -450,6 +454,8 @@ const TatieOrderNew = () => {
   if (ans !== undefined) {
     TatieOrderAdd([ans])
   }
+  // 立ち絵の変換サンプルを更新
+  refEnterEncodeTatie.value?.enterEncodeTatie()
 }
 
 // tatieOrderListに表示する立ち絵を追加する。
@@ -469,6 +475,10 @@ const TatieOrderAdd = (outSettingTtems: outSettingType[]) => {
 // tatieOrderListに表示する立ち絵を削除する。
 const TatieOrderDel = (index: number) => {
   tatieOrderList.value.splice(index, 1)
+  // 立ち絵の変換サンプルを更新
+  refEnterEncodeTatie.value?.enterEncodeTatie()
+}
+
 }
 
 // キャラ名やスタイル名で検索したときに、
@@ -636,6 +646,7 @@ watch(
         :selectKyara="selectKyara"
         :infoData="infoData"
         :tatieOrderList="tatieOrderList"
+        ref="refEnterEncodeTatie"
       />
       <setKyaraList
         :dateList="dateList"

--- a/src/components/makeComList.vue
+++ b/src/components/makeComList.vue
@@ -651,7 +651,7 @@ watch(
 
 // 設定に編集があったときにはtrueを入れる
 watch(
-  () => (dateList.value, infoData.value, tatieOrderList.value),
+  () => [dateList.value, infoData.value, tatieOrderList.value],
   () => {
     props.setChangeDataSettingSta(true)
   },

--- a/src/components/makeComList.vue
+++ b/src/components/makeComList.vue
@@ -498,11 +498,11 @@ const TatieOrderAdd = (outSettingTtems: outSettingType[]) => {
 
 // editTatieOrderListに表示する立ち絵を、選択されたキャラに変更する。
 const TatieOrderChange = (uuid: string, outSetting: outSettingType) => {
-  const changeItemindex = tatieOrderList.value.findIndex((e) => e.uuid === uuid)
+  const changeItemindex = editTatieOrderList.value.findIndex((e) => e.uuid === uuid)
 
   // 値が見つかったら変更
   if (changeItemindex !== -1) {
-    tatieOrderList.value[changeItemindex] = {
+    editTatieOrderList.value[changeItemindex] = {
       uuid: uuid,
       dataType: outSetting.dataType,
       name: outSetting.name,

--- a/src/components/makeComList.vue
+++ b/src/components/makeComList.vue
@@ -477,6 +477,11 @@ const TatieOrderAdd = (outSettingTtems: outSettingType[]) => {
   }
 }
 
+// tatieOrderListに表示する立ち絵を削除する。
+const TatieOrderDel = (index: number) => {
+  tatieOrderList.value.splice(index, 1)
+}
+
 // キャラ名やスタイル名で検索したときに、
 // 現在表示中のキャラ設定がリストに表示されなくなったか確認する。
 // 表示されなくなったら、表示されている項目に切り替える。
@@ -750,6 +755,7 @@ watch(
           :TatieOrderDragStart="TatieOrderDragStart"
           :TatieOrderDragMove="TatieOrderDragMove"
           :TatieOrderNew="TatieOrderNew"
+          :TatieOrderDel="TatieOrderDel"
           v-else-if="settype === 'tatieOrder' || (editData === 'tatieOrder' && dateList[selectKyara] !== undefined)"
         />
         <setTatie

--- a/src/components/makeComList.vue
+++ b/src/components/makeComList.vue
@@ -451,8 +451,8 @@ const TatieOrderDragMove = (index: number) => {
   // indexで指定された場所に差し込む形で追加する。
   // 処理が終わったら dragStartIndex.value と index の値を一致させて処理が無駄に実行されないようにする。
   if (index !== dragStartIndex.value) {
-    const moveItem = tatieOrderList.value.splice(dragStartIndex.value, 1)[0]
-    tatieOrderList.value.splice(index, 0, moveItem)
+    const moveItem = editTatieOrderList.value.splice(dragStartIndex.value, 1)[0]
+    editTatieOrderList.value.splice(index, 0, moveItem)
     dragStartIndex.value = index
     // 立ち絵の変換サンプルを更新
     refEnterEncodeTatie.value?.enterEncodeTatie()
@@ -465,7 +465,7 @@ const TatieOrderDragMove = (index: number) => {
 const TatieOrderNew = () => {
   const ans = dateList.value.find((e) => {
     return (
-      tatieOrderList.value.findIndex(
+      editTatieOrderList.value.findIndex(
         (f) => e.dataType + e.name + e.kyaraStyle === f.dataType + f.name + f.kyaraStyle,
       ) === -1 &&
       (e.tatie.waitTatieUUID.active || e.tatie.tatieUUID.active)
@@ -482,11 +482,11 @@ const TatieOrderNew = () => {
   }
 }
 
-// tatieOrderListに表示する立ち絵を追加する。
+// editTatieOrderListに表示する立ち絵を追加する。
 // 配列で複数の立ち絵順序の設定をできる。
 const TatieOrderAdd = (outSettingTtems: outSettingType[]) => {
   for (const item of outSettingTtems) {
-    tatieOrderList.value.push({
+    editTatieOrderList.value.push({
       uuid: yomAPI.getUUID(),
       dataType: item.dataType,
       name: item.name,
@@ -496,7 +496,7 @@ const TatieOrderAdd = (outSettingTtems: outSettingType[]) => {
   }
 }
 
-// tatieOrderListに表示する立ち絵を、選択されたキャラに変更する。
+// editTatieOrderListに表示する立ち絵を、選択されたキャラに変更する。
 const TatieOrderChange = (uuid: string, outSetting: outSettingType) => {
   const changeItemindex = tatieOrderList.value.findIndex((e) => e.uuid === uuid)
 
@@ -514,19 +514,19 @@ const TatieOrderChange = (uuid: string, outSetting: outSettingType) => {
   refEnterEncodeTatie.value?.enterEncodeTatie()
 }
 
-// tatieOrderListに表示する立ち絵を削除する。
+// editTatieOrderListに表示する立ち絵を削除する。
 const TatieOrderDel = (index: number) => {
-  tatieOrderList.value.splice(index, 1)
+  editTatieOrderList.value.splice(index, 1)
   // 立ち絵の変換サンプルを更新
   refEnterEncodeTatie.value?.enterEncodeTatie()
 }
 
-// tatieOrderListのtatieSituation設定を変更する。
+// editTatieOrderListのtatieSituation設定を変更する。
 const TatieOrderChangeSituation = (index: number) => {
-  if (tatieOrderList.value[index].tatieSituation === 'tatieUUID') {
-    tatieOrderList.value[index].tatieSituation = 'waitTatieUUID'
+  if (editTatieOrderList.value[index].tatieSituation === 'tatieUUID') {
+    editTatieOrderList.value[index].tatieSituation = 'waitTatieUUID'
   } else {
-    tatieOrderList.value[index].tatieSituation = 'tatieUUID'
+    editTatieOrderList.value[index].tatieSituation = 'tatieUUID'
   }
   // 立ち絵の変換サンプルを更新
   refEnterEncodeTatie.value?.enterEncodeTatie()
@@ -682,7 +682,7 @@ watch(
 
 // 設定に編集があったときにはtrueを入れる
 watch(
-  () => [dateList.value, infoData.value, tatieOrderList.value],
+  () => [dateList.value, infoData.value, editTatieOrderList.value],
   () => {
     props.setChangeDataSettingSta(true)
   },

--- a/src/components/makeComList.vue
+++ b/src/components/makeComList.vue
@@ -66,24 +66,7 @@ const inputProfileUUID = ref<string>(globalSetting.selectProfile)
 const inputProfileData = <inputProfileSendReType>loadProfile(inputProfileUUID.value)
 const dateList = ref<outSettingType[]>(inputProfileData.settingList)
 const infoData = ref<infoSettingType>(inputProfileData.infoSetting)
-const tatieOrderList = ref<tatieOrderListType[]>([
-  { uuid: 'sa1', dataType: 'kyara', name: '四国めたん', kyaraStyle: undefined, tatieSituation: 'waitTatieUUID' },
-  { uuid: 'sa2', dataType: 'kyara', name: 'ずんだもん', kyaraStyle: undefined, tatieSituation: 'waitTatieUUID' },
-  {
-    uuid: 'sa3',
-    dataType: 'kyast',
-    name: '四国めたん',
-    kyaraStyle: 'あまあま',
-    tatieSituation: 'tatieUUID',
-  },
-  {
-    uuid: 'sa4',
-    dataType: 'kyast',
-    name: '九州そら',
-    kyaraStyle: 'ささやき',
-    tatieSituation: 'waitTatieUUID',
-  },
-])
+const tatieOrderList = ref<tatieOrderListType[]>(inputProfileData.tatieOrderList)
 
 // 立ち絵UUID情報の読み込み
 const fileListTatie = ref<fileListTatieType[]>(readFileListTatieData())
@@ -321,6 +304,7 @@ const createProfileData = async (copyUuid: boolean): Promise<string> => {
     const ans = writeProfilleSettingData(
       uuid,
       infoData.value,
+      tatieOrderList.value,
       dateList.value.filter((item) => item.dataType !== 'seid'),
     )
     return uuid
@@ -337,7 +321,7 @@ const writeSettingData = (): void => {
   const voiceDirData = dateList.value.filter((item) => item.dataType === 'seid') // 音声ファイルのあるディレクトリ
 
   // キャラ設定プロファイルの書き込み
-  const ans = writeProfilleSettingData(inputProfileUUID.value, infoData.value, settingListDate)
+  const ans = writeProfilleSettingData(inputProfileUUID.value, infoData.value, tatieOrderList.value, settingListDate)
 
   // 音声ファイルディレクトリを読み込んでいれば記録する
   let ans2 = true
@@ -415,6 +399,7 @@ const onChangeKyaraProfile = (uuid: string): void => {
   const profile = <inputProfileSendReType>loadProfile(uuid)
   dateList.value = profile.settingList
   infoData.value = profile.infoSetting
+  tatieOrderList.value = profile.tatieOrderList
   inputProfileUUID.value = uuid
 
   // 起動時に開くプロファイルを変更する。

--- a/src/components/makeComList.vue
+++ b/src/components/makeComList.vue
@@ -633,7 +633,6 @@ watch(
         :selectKyara="selectKyara"
         :infoData="infoData"
         :tatieOrderList="tatieOrderList"
-        :onSampleView="dateList[selectKyara] !== undefined || settype === 'tatieOrder'"
       />
       <setKyaraList
         :dateList="dateList"

--- a/src/components/makeComList.vue
+++ b/src/components/makeComList.vue
@@ -441,6 +441,7 @@ const TatieOrderDragMove = (index: number) => {
 
 // 立ち絵順序の設定で、表示する立ち絵を追加する。
 // まだ追加されておらず、立ち絵が設定されているキャラ設定を調べて、それを追加する。
+// ない場合はデフォルトの項目を追加する。
 const TatieOrderNew = () => {
   const ans = dateList.value.find((e) => {
     return (
@@ -453,9 +454,12 @@ const TatieOrderNew = () => {
 
   if (ans !== undefined) {
     TatieOrderAdd([ans])
+
+    // 立ち絵の変換サンプルを更新
+    refEnterEncodeTatie.value?.enterEncodeTatie()
+  } else {
+    TatieOrderAdd([dateList.value[0]])
   }
-  // 立ち絵の変換サンプルを更新
-  refEnterEncodeTatie.value?.enterEncodeTatie()
 }
 
 // tatieOrderListに表示する立ち絵を追加する。

--- a/src/components/makeComList.vue
+++ b/src/components/makeComList.vue
@@ -164,6 +164,7 @@ const addNewKyara = (dataType: dataTextType, kyaraName: string, kyaraStyle: stri
           undefined,
           undefined,
           undefined,
+          undefined,
           yomAPI.getPlatformData(),
         ),
       )

--- a/src/components/makeComList.vue
+++ b/src/components/makeComList.vue
@@ -708,7 +708,8 @@ watch(
         :higherUpList="higherUpList"
         :selectKyara="selectKyara"
         :infoData="infoData"
-        :tatieOrderList="tatieOrderList"
+        :tatieOrderList="editTatieOrderList"
+        :isFileTatieOrderSetting="isFileTatieOrderSetting"
         ref="refEnterEncodeTatie"
       />
       <setKyaraList
@@ -815,7 +816,8 @@ watch(
           :higherUpList="higherUpList"
           :fileListTatie="fileListTatie"
           :inputProfileUUID="inputProfileUUID"
-          :tatieOrderList="tatieOrderList"
+          :tatieOrderList="editTatieOrderList"
+          :isFileTatieOrderSetting="isFileTatieOrderSetting"
           :TatieOrderDragStart="TatieOrderDragStart"
           :TatieOrderDragMove="TatieOrderDragMove"
           :TatieOrderNew="TatieOrderNew"

--- a/src/components/makeComList.vue
+++ b/src/components/makeComList.vue
@@ -434,6 +434,7 @@ const TatieOrderDragStart = (index: number) => {
   dragStartIndex.value = index
 }
 
+// 立ち絵の順番を入れ替える
 const TatieOrderDragMove = (index: number) => {
   // もし、移動されていた場合は移動対象の配列要素を取り出して、
   // indexで指定された場所に差し込む形で追加する。
@@ -442,6 +443,37 @@ const TatieOrderDragMove = (index: number) => {
     const moveItem = tatieOrderList.value.splice(dragStartIndex.value, 1)[0]
     tatieOrderList.value.splice(index, 0, moveItem)
     dragStartIndex.value = index
+  }
+}
+
+// 立ち絵順序の設定で、表示する立ち絵を追加する。
+// まだ追加されておらず、立ち絵が設定されているキャラ設定を調べて、それを追加する。
+const TatieOrderNew = () => {
+  const ans = dateList.value.find((e) => {
+    return (
+      tatieOrderList.value.findIndex(
+        (f) => e.dataType + e.name + e.kyaraStyle === f.dataType + f.name + f.kyaraStyle,
+      ) === -1 &&
+      (e.tatie.waitTatieUUID.active || e.tatie.tatieUUID.active)
+    )
+  })
+
+  if (ans !== undefined) {
+    TatieOrderAdd([ans])
+  }
+}
+
+// tatieOrderListに表示する立ち絵を追加する。
+// 配列で複数の立ち絵順序の設定をできる。
+const TatieOrderAdd = (outSettingTtems: outSettingType[]) => {
+  for (const item of outSettingTtems) {
+    tatieOrderList.value.push({
+      uuid: yomAPI.getUUID(),
+      dataType: item.dataType,
+      name: item.name,
+      kyaraStyle: item.dataType === 'kyast' ? item.kyaraStyle : undefined,
+      tatieSituation: item.tatie.waitTatieUUID.active ? 'waitTatieUUID' : 'tatieUUID',
+    })
   }
 }
 
@@ -717,6 +749,7 @@ watch(
           :tatieOrderList="tatieOrderList"
           :TatieOrderDragStart="TatieOrderDragStart"
           :TatieOrderDragMove="TatieOrderDragMove"
+          :TatieOrderNew="TatieOrderNew"
           v-else-if="settype === 'tatieOrder' || (editData === 'tatieOrder' && dateList[selectKyara] !== undefined)"
         />
         <setTatie

--- a/src/components/makeComList.vue
+++ b/src/components/makeComList.vue
@@ -479,6 +479,15 @@ const TatieOrderDel = (index: number) => {
   refEnterEncodeTatie.value?.enterEncodeTatie()
 }
 
+// tatieOrderListのtatieSituation設定を変更する。
+const TatieOrderChangeSituation = (index: number) => {
+  if (tatieOrderList.value[index].tatieSituation === 'tatieUUID') {
+    tatieOrderList.value[index].tatieSituation = 'waitTatieUUID'
+  } else {
+    tatieOrderList.value[index].tatieSituation = 'tatieUUID'
+  }
+  // 立ち絵の変換サンプルを更新
+  refEnterEncodeTatie.value?.enterEncodeTatie()
 }
 
 // キャラ名やスタイル名で検索したときに、
@@ -757,6 +766,7 @@ watch(
           :TatieOrderDragMove="TatieOrderDragMove"
           :TatieOrderNew="TatieOrderNew"
           :TatieOrderDel="TatieOrderDel"
+          :TatieOrderChangeSituation="TatieOrderChangeSituation"
           v-else-if="settype === 'tatieOrder' || (editData === 'tatieOrder' && dateList[selectKyara] !== undefined)"
         />
         <setTatie

--- a/src/components/makeComList.vue
+++ b/src/components/makeComList.vue
@@ -126,6 +126,13 @@ const closeEncodeDialog = (): void => {
   encodeAns.value = ''
 }
 
+// どちらのtatieOrderListを使用するか判断する変数
+// true ならfileTatieOrderList、falesならプロファイルのtatieOrderListとなる
+const isFileTatieOrderSetting = ref<boolean>(false)
+
+// 使用するtatieOrderListを選択
+const editTatieOrderList = ref<tatieOrderListType[]>(tatieOrderList.value)
+
 // 選択中のボタンの場合は背景色を変更する
 const actset = (editSet: selectedEditDataType): string => {
   return (
@@ -420,6 +427,18 @@ const searchKyaraEvent = (text: string) => {
   console.log('searchKyaraString: ' + searchKyaraString.value)
 }
 
+// seidキャラ設定のfileTatieOrderListを子コンポーネントに渡すか判断する
+// true ならfileTatieOrderList、falesならプロファイルのtatieOrderListとなる
+const selectFileTatieOrderSetting = (): void => {
+  if (props.settype === 'seid' && dateList.value[selectKyara.value]?.fileTatieOrderList.active) {
+    isFileTatieOrderSetting.value = true
+    editTatieOrderList.value = dateList.value[selectKyara.value]?.fileTatieOrderList.val
+  } else {
+    isFileTatieOrderSetting.value = false
+    editTatieOrderList.value = tatieOrderList.value
+  }
+}
+
 // 立ち絵の表示順をマウスで入れ替えるため、
 // 移動開始時の数値を保存する
 const TatieOrderDragStart = (index: number) => {
@@ -635,6 +654,9 @@ watch(
         }
       }
     }
+
+    // プロファイル全体か個別かどちらのtatieOrderListを利用するか決める
+    selectFileTatieOrderSetting()
   },
 )
 
@@ -646,6 +668,15 @@ watch(
     if (dateList.value[selectKyara.value] !== undefined) {
       higherUpList.value = SelectHigherUpIndexList(props.settype, dateList.value, selectKyara.value)
     }
+  },
+)
+
+// seidのfileTatieOrderList.activeが変更されたときに、どのtatieOrderListを利用するか決める
+watch(
+  () => dateList.value[selectKyara.value]?.fileTatieOrderList.active,
+  () => {
+    // プロファイル全体か個別かどちらのtatieOrderListを利用するか決める
+    selectFileTatieOrderSetting()
   },
 )
 

--- a/src/components/makeComList.vue
+++ b/src/components/makeComList.vue
@@ -818,6 +818,8 @@ watch(
           :inputProfileUUID="inputProfileUUID"
           :tatieOrderList="editTatieOrderList"
           :isFileTatieOrderSetting="isFileTatieOrderSetting"
+          :subTextStringList="subTextStringList"
+          :useSubText="globalSetting.useSubText"
           :TatieOrderDragStart="TatieOrderDragStart"
           :TatieOrderDragMove="TatieOrderDragMove"
           :TatieOrderNew="TatieOrderNew"

--- a/src/components/makeComList.vue
+++ b/src/components/makeComList.vue
@@ -521,6 +521,17 @@ const TatieOrderDel = (index: number) => {
   refEnterEncodeTatie.value?.enterEncodeTatie()
 }
 
+// プロファイルの立ち絵順序の設定に選択中のキャラ設定がある場合は、trueを返して削除を行わないようにする。
+const checkIntoTatieOrderList = (uuid: string): boolean => {
+  const ans = tatieOrderList.value.findIndex((e) => e.settingUUID === uuid)
+
+  if (ans !== -1) {
+    return true
+  } else {
+    return false
+  }
+}
+
 // editTatieOrderListのtatieSituation設定を変更する。
 const TatieOrderChangeSituation = (index: number) => {
   if (editTatieOrderList.value[index].tatieSituation === 'tatieUUID') {
@@ -727,6 +738,7 @@ watch(
         :createProfileData="createProfileData"
         :subTextStringList="subTextStringList"
         :useSubText="globalSetting.useSubText"
+        :checkIntoTatieOrderList="(uuid: string) => checkIntoTatieOrderList(uuid)"
         :searchKyaraEvent="searchKyaraEvent"
         :CopyKyaraSetting="CopyKyaraSetting"
         ref="setKyaraListRef"

--- a/src/components/makeComList.vue
+++ b/src/components/makeComList.vue
@@ -787,6 +787,7 @@ watch(
           :TatieOrderDragStart="TatieOrderDragStart"
           :TatieOrderDragMove="TatieOrderDragMove"
           :TatieOrderNew="TatieOrderNew"
+          :TatieOrderChange="TatieOrderChange"
           :TatieOrderDel="TatieOrderDel"
           :TatieOrderChangeSituation="TatieOrderChangeSituation"
           v-else-if="settype === 'tatieOrder' || (editData === 'tatieOrder' && dateList[selectKyara] !== undefined)"

--- a/src/components/makeComList.vue
+++ b/src/components/makeComList.vue
@@ -33,7 +33,6 @@ import {
   createNewDataID,
   createNewDateList,
   SelectHigherUpIndexList,
-  createVoiceFileEncodeSetting,
   getGlobalSetting,
   loadProfile,
   writeGlobalSetting,
@@ -356,8 +355,12 @@ const entOpen = (): void => {
 const encodeAndDisplay = async (index: number): Promise<void> => {
   await enterEncodeVideoFile(
     voiceLoadDirPath.value,
-    createVoiceFileEncodeSetting(index, dateList.value),
+    index,
     infoData.value,
+    'tatieUUID',
+    dateList.value,
+    'seid',
+    tatieOrderList.value,
   )
   encodeAns.value = 'エンコード完了: ' + dateList.value[index].fileName
 }

--- a/src/components/makeComList.vue
+++ b/src/components/makeComList.vue
@@ -532,6 +532,12 @@ const checkIntoTatieOrderList = (uuid: string): boolean => {
   }
 }
 
+// プロファイルの立ち絵順序の設定を、指定したファイルの個別ファイルの立ち絵順序にコピーする
+const CopyTatieOrderListToFileList = (index: number): void => {
+  dateList.value[index].fileTatieOrderList.val = JSON.parse(JSON.stringify(tatieOrderList.value))
+  editTatieOrderList.value = dateList.value[index].fileTatieOrderList.val
+}
+
 // editTatieOrderListのtatieSituation設定を変更する。
 const TatieOrderChangeSituation = (index: number) => {
   if (editTatieOrderList.value[index].tatieSituation === 'tatieUUID') {
@@ -838,6 +844,7 @@ watch(
           :TatieOrderChange="TatieOrderChange"
           :TatieOrderDel="TatieOrderDel"
           :TatieOrderChangeSituation="TatieOrderChangeSituation"
+          :CopyTatieOrderListToFileList="(index: number) => CopyTatieOrderListToFileList(index)"
           v-else-if="settype === 'tatieOrder' || (editData === 'tatieOrder' && dateList[selectKyara] !== undefined)"
         />
         <setTatie

--- a/src/components/makeComList.vue
+++ b/src/components/makeComList.vue
@@ -465,9 +465,7 @@ const TatieOrderDragMove = (index: number) => {
 const TatieOrderNew = () => {
   const ans = dateList.value.find((e) => {
     return (
-      editTatieOrderList.value.findIndex(
-        (f) => e.dataType + e.name + e.kyaraStyle === f.dataType + f.name + f.kyaraStyle,
-      ) === -1 &&
+      editTatieOrderList.value.findIndex((f) => e.dataType + e.uuid === f.dataType + f.settingUUID) === -1 &&
       (e.tatie.waitTatieUUID.active || e.tatie.tatieUUID.active)
     )
   })
@@ -489,6 +487,7 @@ const TatieOrderAdd = (outSettingTtems: outSettingType[]) => {
     editTatieOrderList.value.push({
       uuid: yomAPI.getUUID(),
       dataType: item.dataType,
+      settingUUID: item.uuid,
       name: item.name,
       kyaraStyle: item.dataType === 'kyast' ? item.kyaraStyle : undefined,
       tatieSituation: item.tatie.waitTatieUUID.active ? 'waitTatieUUID' : 'tatieUUID',
@@ -505,6 +504,7 @@ const TatieOrderChange = (uuid: string, outSetting: outSettingType) => {
     editTatieOrderList.value[changeItemindex] = {
       uuid: uuid,
       dataType: outSetting.dataType,
+      settingUUID: outSetting.uuid,
       name: outSetting.name,
       kyaraStyle: outSetting.dataType === 'kyast' ? outSetting.kyaraStyle : undefined,
       tatieSituation: outSetting.tatie.waitTatieUUID.active ? 'waitTatieUUID' : 'tatieUUID',

--- a/src/components/makeComList.vue
+++ b/src/components/makeComList.vue
@@ -628,10 +628,12 @@ watch(
     <div class="mx-1">
       <DisplaySettingSampleView
         :dateList="dateList"
+        :settype="settype"
         :higherUpList="higherUpList"
         :selectKyara="selectKyara"
         :infoData="infoData"
-        :onSampleView="dateList[selectKyara] !== undefined"
+        :tatieOrderList="tatieOrderList"
+        :onSampleView="dateList[selectKyara] !== undefined || settype === 'tatieOrder'"
       />
       <setKyaraList
         :dateList="dateList"

--- a/src/components/makeSetList.vue
+++ b/src/components/makeSetList.vue
@@ -76,6 +76,13 @@ const seveProfile = (): void => {
         <button :class="actset('defo')" @click="setClick('defo')">デフォルト設定</button>
         <button :class="actset('kyara')" @click="setClick('kyara')">各キャラ設定</button>
         <button :class="actset('kyast')" @click="setClick('kyast')">スタイル付キャラ設定</button>
+        <button
+          :class="actset('tatieOrder')"
+          @click="setClick('tatieOrder')"
+          title="どの立ち絵を表示するかと、表示順を設定して前に表示したい立ち絵を決定します。"
+        >
+          立ち絵順序の設定
+        </button>
         <button :class="actset('seid')" @click="setClick('seid')">音声ファイル個別の設定</button>
       </div>
       <div>

--- a/src/components/setKyaraList.vue
+++ b/src/components/setKyaraList.vue
@@ -319,7 +319,7 @@ watch(
         />
       </div>
     </div>
-    <div class="mx-1 mt-2 h-20" v-if="settype !== 'seid' && settype !== 'defo'">
+    <div class="mx-1 mt-2 h-20" v-if="settype !== 'seid' && settype !== 'defo' && settype !== 'tatieOrder'">
       <!-- キャラ設定の追加 seid か defo 以外で表示 -->
       <div class="mx-1 mt-3 flex justify-between">
         <div>

--- a/src/components/setKyaraList.vue
+++ b/src/components/setKyaraList.vue
@@ -228,7 +228,7 @@ watch(
 </script>
 
 <template>
-  <div class="overflow-none mt-2 h-[550px] w-72 border border-gray-700">
+  <div class="overflow-none mt-2 h-[550px] w-80 border border-gray-700">
     <div class="border-gray-600d max-h-full overflow-y-scroll border border-b-4" ref="selectAreaRef">
       <SearchInputUnit
         v-show="settype === 'kyara' || settype === 'kyast'"

--- a/src/components/setKyaraList.vue
+++ b/src/components/setKyaraList.vue
@@ -218,8 +218,10 @@ watch(
   () => {
     // 表示後に現在選択中のキャラ項目を表示するようにスクロールする
     nextTick(() => {
-      const selectDiv = props.dateList.findIndex((e) => e.uuid === props.dateList[props.selectKyara].uuid)
-      kyaraRefs.value[selectDiv].scrollIntoView(false)
+      const selectDiv = props.dateList.findIndex((e) => e.uuid === props.dateList[props.selectKyara]?.uuid)
+      if (selectDiv !== -1) {
+        kyaraRefs.value[selectDiv].scrollIntoView(false)
+      }
     })
   },
 )

--- a/src/components/setKyaraList.vue
+++ b/src/components/setKyaraList.vue
@@ -13,6 +13,7 @@ const props = defineProps<{
   createProfileData: (copyUuid: boolean) => Promise<string>
   subTextStringList: { [key: string]: { val: string; active: boolean } }
   useSubText: boolean
+  checkIntoTatieOrderList: (uuid: string) => boolean
   searchKyaraEvent: (text: string) => void
   CopyKyaraSetting: (dataType: dataTextType, uuid: string) => void
 }>()
@@ -200,8 +201,10 @@ yomAPI.EntEditName(() => {
 
 // ショートカットキーで削除のコマンドがあった場合は削除ダイアログを開く
 yomAPI.EntAskDelete(() => {
-  isMenuOpen.value = false
-  props.askDeleteKyara(props.selectKyara)
+  if (props.checkIntoTatieOrderList(props.dateList[props.selectKyara].uuid) === false) {
+    isMenuOpen.value = false
+    props.askDeleteKyara(props.selectKyara)
+  }
 })
 
 // props.settype, props.selectKyaraが変更されたときの処理
@@ -279,6 +282,7 @@ watch(
                 :CopyKyaraSetting="(settype: dataTextType) => CopyKyaraSetting(settype, item.uuid)"
                 :editDataClik="() => editDataClik(item.uuid, item.name, item.kyaraStyle)"
                 :askDeleteKyara="() => askDeleteKyara(index)"
+                :checkIntoTatieOrderList="() => checkIntoTatieOrderList(item.uuid)"
               />
             </div>
           </div>

--- a/src/components/setTatieOrder.vue
+++ b/src/components/setTatieOrder.vue
@@ -10,6 +10,7 @@ const props = defineProps<{
   TatieOrderDragStart: (index: number) => void
   TatieOrderDragMove: (index: number) => void
   TatieOrderNew: () => void
+  TatieOrderDel: (index: number) => void
 }>()
 // 複数の立ち絵の表示順番を設定します。
 
@@ -17,38 +18,54 @@ import type { dataTextType, outSettingType, fileListTatieType, tatieOrderListTyp
 import MaterialIcons from '@/components/accessories/icons/MaterialIcons.vue'
 import { typeColor } from '@/data/data'
 import { MakeClassString } from '@/utils/analysisGeneral'
+import deleteDialog from '@/components/accessories/deleteDialog.vue'
+import { ref } from 'vue'
+
+const isDeleteDialogOpen = ref<boolean>(false)
+
+const isDeleteIndex = ref<number>()
+
+const AskDelete = (index: number): void => {
+  isDeleteIndex.value = index
+  isDeleteDialogOpen.value = true
+}
 </script>
 
 <template>
   <div class="h-full w-full">
     <div class="flex h-full w-full flex-col items-center overflow-y-scroll border border-gray-500 px-2 py-1">
       <div
-        class="mt-1 flex w-[580px] truncate rounded-xl border border-black"
+        class="mt-1 flex w-[580px] justify-between rounded-xl border border-black"
         v-for="(item, index) in tatieOrderList"
         v-bind:key="item.uuid"
         :draggable="true"
         @dragstart="() => TatieOrderDragStart(index)"
         @dragenter="() => TatieOrderDragMove(index)"
       >
-        <div class="my-1 ml-1 rounded-3xl border border-black px-2">{{ index }}</div>
-        <div
-          :class="
-            MakeClassString(
-              'my-1 ml-1 flex items-center rounded-3xl border border-black px-2',
-              typeColor[item.dataType].bg,
-            )
-          "
-          :title="item.name + (item.dataType === 'kyast' ? '（' + item.kyaraStyle + '）' : '')"
-        >
-          <div class="max-w-52 truncate">{{ item.name }}</div>
-          <div class="max-w-40 truncate" v-if="item.dataType === 'kyast'">
-            {{ '（' + item.kyaraStyle + '）' }}
+        <div class="flex truncate">
+          <div class="my-1 ml-2 rounded-3xl border border-black px-2">{{ index }}</div>
+          <div
+            :class="
+              MakeClassString(
+                'my-1 ml-1 flex items-center rounded-3xl border border-black px-2',
+                typeColor[item.dataType].bg,
+              )
+            "
+            :title="item.name + (item.dataType === 'kyast' ? '（' + item.kyaraStyle + '）' : '')"
+          >
+            <div class="max-w-52 truncate">{{ item.name }}</div>
+            <div class="max-w-40 truncate" v-if="item.dataType === 'kyast'">
+              {{ '（' + item.kyaraStyle + '）' }}
+            </div>
+          </div>
+          <MaterialIcons classString="w-5" icon="ArrowForward400024" />
+          <div class="my-1 ml-1 rounded-3xl border border-black px-2">
+            {{ item.tatieSituation === 'waitTatieUUID' ? '待機中' : '会話中' }}
           </div>
         </div>
-        <MaterialIcons classString="w-5" icon="ArrowForward400024" />
-        <div class="my-1 ml-1 rounded-3xl border border-black px-2">
-          {{ item.tatieSituation === 'waitTatieUUID' ? '待機中' : '会話中' }}
-        </div>
+        <button @click="() => AskDelete(index)" title="リストから削除" class="h-9 w-9 p-1">
+          <MaterialIcons icon="Delete" />
+        </button>
       </div>
     </div>
     <div class="mt-1 flex justify-end px-2">
@@ -60,5 +77,13 @@ import { MakeClassString } from '@/utils/analysisGeneral'
         <MaterialIcons icon="AddCircle" />
       </button>
     </div>
+    <deleteDialog
+      :deleteTitle="'リストから削除'"
+      :clickClose="() => (isDeleteDialogOpen = false)"
+      :deleteButtonTitle="'削除'"
+      :deleteMessage="'この立ち絵を表示順リストから削除しますか？'"
+      :deleteKyara="() => TatieOrderDel(isDeleteIndex)"
+      v-if="isDeleteDialogOpen"
+    />
   </div>
 </template>

--- a/src/components/setTatieOrder.vue
+++ b/src/components/setTatieOrder.vue
@@ -11,6 +11,7 @@ const props = defineProps<{
   TatieOrderDragMove: (index: number) => void
   TatieOrderNew: () => void
   TatieOrderDel: (index: number) => void
+  TatieOrderChangeSituation: (index: number) => void
 }>()
 // 複数の立ち絵の表示順番を設定します。
 
@@ -44,7 +45,7 @@ const AskDelete = (index: number): void => {
       >
         <div class="flex truncate">
           <div class="my-1 ml-2 rounded-3xl border border-black px-2">{{ index }}</div>
-          <div
+          <button
             :class="
               MakeClassString(
                 'my-1 ml-1 flex items-center rounded-3xl border border-black px-2',
@@ -57,11 +58,15 @@ const AskDelete = (index: number): void => {
             <div class="max-w-40 truncate" v-if="item.dataType === 'kyast'">
               {{ '（' + item.kyaraStyle + '）' }}
             </div>
-          </div>
+          </button>
           <MaterialIcons classString="w-5" icon="ArrowForward400024" />
-          <div class="my-1 ml-1 rounded-3xl border border-black px-2">
+          <button
+            class="my-1 ml-1 rounded-3xl border border-black px-2"
+            @click="() => TatieOrderChangeSituation(index)"
+            title="クリックで設定変更します"
+          >
             {{ item.tatieSituation === 'waitTatieUUID' ? '待機中' : '会話中' }}
-          </div>
+          </button>
         </div>
         <button @click="() => AskDelete(index)" title="リストから削除" class="h-9 w-9 p-1">
           <MaterialIcons icon="Delete" />

--- a/src/components/setTatieOrder.vue
+++ b/src/components/setTatieOrder.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+const props = defineProps<{
+  selectKyara: number
+  settype: dataTextType
+  dateList: outSettingType[]
+  higherUpList: [number, number]
+  fileListTatie: fileListTatieType[]
+  inputProfileUUID: string
+  tatieOrderList: tatieOrderListType[]
+  TatieOrderDragStart: (index: number) => void
+  TatieOrderDragMove: (index: number) => void
+}>()
+// 複数の立ち絵の表示順番を設定します。
+
+import type { dataTextType, outSettingType, fileListTatieType, tatieOrderListType } from 'src/type/data-type'
+import MaterialIcons from '@/components/accessories/icons/MaterialIcons.vue'
+import { typeColor } from '@/data/data'
+import { MakeClassString } from '@/utils/analysisGeneral'
+</script>
+
+<template>
+  <div class="flex h-full w-full flex-col items-center overflow-y-scroll border border-gray-500 px-2 py-1">
+    <div
+      class="mt-1 flex w-[580px] truncate rounded-xl border border-black"
+      v-for="(item, index) in tatieOrderList"
+      v-bind:key="item.uuid"
+      :draggable="true"
+      @dragstart="() => TatieOrderDragStart(index)"
+      @dragenter="() => TatieOrderDragMove(index)"
+    >
+      <div class="my-1 ml-1 rounded-3xl border border-black px-2">{{ index }}</div>
+      <div
+        :class="
+          MakeClassString(
+            'my-1 ml-1 flex items-center rounded-3xl border border-black px-2',
+            typeColor[item.dataType].bg,
+          )
+        "
+        :title="item.name + (item.dataType === 'kyast' ? '（' + item.kyaraStyle + '）' : '')"
+      >
+        <div class="max-w-52 truncate">{{ item.name }}</div>
+        <div class="max-w-40 truncate" v-if="item.dataType === 'kyast'">
+          {{ '（' + item.kyaraStyle + '）' }}
+        </div>
+      </div>
+      <MaterialIcons classString="w-5" icon="ArrowForward400024" />
+      <div class="my-1 ml-1 rounded-3xl border border-black px-2">
+        {{ item.tatieSituation === 'waitTatieUUID' ? '待機中' : '会話中' }}
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/setTatieOrder.vue
+++ b/src/components/setTatieOrder.vue
@@ -16,6 +16,7 @@ const props = defineProps<{
   TatieOrderChange: (uuid: string, outSetting: outSettingType) => void
   TatieOrderDel: (index: number) => void
   TatieOrderChangeSituation: (index: number) => void
+  CopyTatieOrderListToFileList: (index: number) => void
 }>()
 // 複数の立ち絵の表示順番を設定します。
 
@@ -99,31 +100,46 @@ const OpenSelectDisplayTatieOrderKyara = (uuid: string, name: string, style?: st
         v-if="!(props.settype === 'tatieOrder' || isFileTatieOrderSetting)"
       ></div>
     </div>
-    <div class="mt-1 flex justify-end px-2">
-      <button
-        @click="
-          () => (dateList[selectKyara].fileTatieOrderList.active = !dateList[selectKyara].fileTatieOrderList.active)
-        "
-        :title="
-          dateList[selectKyara].fileTatieOrderList.active
-            ? '個別の立ち絵配置設定を無効化'
-            : '個別の立ち絵配置設定を有効化'
-        "
-        class="mr-2 h-9 w-9 rounded-md border border-black"
-        v-if="settype === 'seid'"
-      >
-        <MaterialIcons
-          :classString="dateList[selectKyara].fileTatieOrderList.active === false ? 'opacity-50' : ''"
-          :icon="dateList[selectKyara].fileTatieOrderList.active ? 'RadioButtonChecked' : 'RadioButtonUnchecked'"
-        />
-      </button>
-      <button
-        @click="() => TatieOrderNew()"
-        title="立ち絵が設定されているキャラ設定の追加（立ち絵が設定されているものが優先的に追加されます）"
-        class="h-9 w-9 rounded-md border border-black"
-      >
-        <MaterialIcons icon="AddCircle" />
-      </button>
+    <div class="mt-1 flex justify-between px-2">
+      <div>
+        <button
+          @click="
+            () => (dateList[selectKyara].fileTatieOrderList.active = !dateList[selectKyara].fileTatieOrderList.active)
+          "
+          :title="
+            dateList[selectKyara].fileTatieOrderList.active
+              ? '個別の立ち絵配置設定を無効化'
+              : '個別の立ち絵配置設定を有効化'
+          "
+          class="h-9 w-9 rounded-md border border-black"
+          v-if="settype === 'seid'"
+        >
+          <MaterialIcons
+            :icon="dateList[selectKyara].fileTatieOrderList.active ? 'RadioButtonChecked' : 'RadioButtonUnchecked'"
+          />
+        </button>
+      </div>
+      <div>
+        <button
+          @click="CopyTatieOrderListToFileList(selectKyara)"
+          title="プロファイルの立ち絵配置をコピーします"
+          class="mr-2 h-9 w-9 rounded-md border border-black"
+          v-if="settype === 'seid'"
+          :disabled="dateList[selectKyara].fileTatieOrderList.active === false"
+        >
+          <MaterialIcons
+            :classString="dateList[selectKyara].fileTatieOrderList.active === false ? 'opacity-50' : ''"
+            icon="PhotoLibrary"
+          />
+        </button>
+        <button
+          @click="() => TatieOrderNew()"
+          title="立ち絵が設定されているキャラ設定の追加（立ち絵が設定されているものが優先的に追加されます）"
+          class="h-9 w-9 rounded-md border border-black"
+        >
+          <MaterialIcons icon="AddCircle" />
+        </button>
+      </div>
     </div>
     <SelectDisplayTatieOrderKyara
       :clickClose="() => (isSelectDisplayTatieOrderKyaraOpen = false)"

--- a/src/components/setTatieOrder.vue
+++ b/src/components/setTatieOrder.vue
@@ -10,6 +10,7 @@ const props = defineProps<{
   TatieOrderDragStart: (index: number) => void
   TatieOrderDragMove: (index: number) => void
   TatieOrderNew: () => void
+  TatieOrderChange: (uuid: string, outSetting: outSettingType) => void
   TatieOrderDel: (index: number) => void
   TatieOrderChangeSituation: (index: number) => void
 }>()
@@ -20,15 +21,31 @@ import MaterialIcons from '@/components/accessories/icons/MaterialIcons.vue'
 import { typeColor } from '@/data/data'
 import { MakeClassString } from '@/utils/analysisGeneral'
 import deleteDialog from '@/components/accessories/deleteDialog.vue'
+import SelectDisplayTatieOrderKyara from '@/components/accessories/SelectDisplayTatieOrderKyara.vue'
 import { ref } from 'vue'
 
 const isDeleteDialogOpen = ref<boolean>(false)
 
 const isDeleteIndex = ref<number>()
 
+// キャラ設定の選択を行う画面を表示させるための変数
+const isSelectDisplayTatieOrderKyaraOpen = ref<boolean>(false)
+const selectTatieOrderListUUID = ref<string>()
+const selectDataType = ref<dataTextType>('defo')
+const selectKyaraName = ref<string>()
+const selectKyaraStyle = ref<string>()
+
 const AskDelete = (index: number): void => {
   isDeleteIndex.value = index
   isDeleteDialogOpen.value = true
+}
+
+// キャラ設定の選択を行う画面を表示する
+const OpenSelectDisplayTatieOrderKyara = (uuid: string, name: string, style?: string): void => {
+  selectTatieOrderListUUID.value = uuid
+  selectKyaraName.value = name
+  selectKyaraStyle.value = style
+  isSelectDisplayTatieOrderKyaraOpen.value = true
 }
 </script>
 
@@ -53,6 +70,7 @@ const AskDelete = (index: number): void => {
               )
             "
             :title="item.name + (item.dataType === 'kyast' ? '（' + item.kyaraStyle + '）' : '')"
+            @click="() => OpenSelectDisplayTatieOrderKyara(item.uuid, item.name, item.kyaraStyle)"
           >
             <div class="max-w-52 truncate">{{ item.name }}</div>
             <div class="max-w-40 truncate" v-if="item.dataType === 'kyast'">
@@ -82,6 +100,16 @@ const AskDelete = (index: number): void => {
         <MaterialIcons icon="AddCircle" />
       </button>
     </div>
+    <SelectDisplayTatieOrderKyara
+      :clickClose="() => (isSelectDisplayTatieOrderKyaraOpen = false)"
+      :TatieOrderChange="TatieOrderChange"
+      :dateList="dateList"
+      :selectTatieOrderListUUID="selectTatieOrderListUUID"
+      :selectDataType="selectDataType"
+      :selectKyaraName="selectKyaraName"
+      :selectKyaraStyle="selectKyaraStyle"
+      v-if="isSelectDisplayTatieOrderKyaraOpen"
+    />
     <deleteDialog
       :deleteTitle="'リストから削除'"
       :clickClose="() => (isDeleteDialogOpen = false)"

--- a/src/components/setTatieOrder.vue
+++ b/src/components/setTatieOrder.vue
@@ -8,6 +8,8 @@ const props = defineProps<{
   inputProfileUUID: string
   tatieOrderList: tatieOrderListType[]
   isFileTatieOrderSetting: boolean
+  subTextStringList: { [key: string]: { val: string; active: boolean } }
+  useSubText: boolean
   TatieOrderDragStart: (index: number) => void
   TatieOrderDragMove: (index: number) => void
   TatieOrderNew: () => void
@@ -131,6 +133,9 @@ const OpenSelectDisplayTatieOrderKyara = (uuid: string, name: string, style?: st
       :selectDataType="selectDataType"
       :selectKyaraName="selectKyaraName"
       :selectKyaraStyle="selectKyaraStyle"
+      :subTextStringList="subTextStringList"
+      :useSubText="useSubText"
+      :settype="settype"
       v-if="isSelectDisplayTatieOrderKyaraOpen"
     />
     <deleteDialog

--- a/src/components/setTatieOrder.vue
+++ b/src/components/setTatieOrder.vue
@@ -54,7 +54,7 @@ const OpenSelectDisplayTatieOrderKyara = (uuid: string, name: string, style?: st
 
 <template>
   <div class="h-full w-full">
-    <div class="relative flex h-full w-full flex-col items-center overflow-y-scroll border border-gray-500 px-2 py-1">
+    <div class="relative flex h-5/6 w-full flex-col items-center overflow-y-scroll border border-gray-500 px-2 py-1">
       <div
         class="mt-1 flex w-[580px] justify-between rounded-xl border border-black"
         v-for="(item, index) in tatieOrderList"

--- a/src/components/setTatieOrder.vue
+++ b/src/components/setTatieOrder.vue
@@ -9,6 +9,7 @@ const props = defineProps<{
   tatieOrderList: tatieOrderListType[]
   TatieOrderDragStart: (index: number) => void
   TatieOrderDragMove: (index: number) => void
+  TatieOrderNew: () => void
 }>()
 // 複数の立ち絵の表示順番を設定します。
 
@@ -19,34 +20,45 @@ import { MakeClassString } from '@/utils/analysisGeneral'
 </script>
 
 <template>
-  <div class="flex h-full w-full flex-col items-center overflow-y-scroll border border-gray-500 px-2 py-1">
-    <div
-      class="mt-1 flex w-[580px] truncate rounded-xl border border-black"
-      v-for="(item, index) in tatieOrderList"
-      v-bind:key="item.uuid"
-      :draggable="true"
-      @dragstart="() => TatieOrderDragStart(index)"
-      @dragenter="() => TatieOrderDragMove(index)"
-    >
-      <div class="my-1 ml-1 rounded-3xl border border-black px-2">{{ index }}</div>
+  <div class="h-full w-full">
+    <div class="flex h-full w-full flex-col items-center overflow-y-scroll border border-gray-500 px-2 py-1">
       <div
-        :class="
-          MakeClassString(
-            'my-1 ml-1 flex items-center rounded-3xl border border-black px-2',
-            typeColor[item.dataType].bg,
-          )
-        "
-        :title="item.name + (item.dataType === 'kyast' ? '（' + item.kyaraStyle + '）' : '')"
+        class="mt-1 flex w-[580px] truncate rounded-xl border border-black"
+        v-for="(item, index) in tatieOrderList"
+        v-bind:key="item.uuid"
+        :draggable="true"
+        @dragstart="() => TatieOrderDragStart(index)"
+        @dragenter="() => TatieOrderDragMove(index)"
       >
-        <div class="max-w-52 truncate">{{ item.name }}</div>
-        <div class="max-w-40 truncate" v-if="item.dataType === 'kyast'">
-          {{ '（' + item.kyaraStyle + '）' }}
+        <div class="my-1 ml-1 rounded-3xl border border-black px-2">{{ index }}</div>
+        <div
+          :class="
+            MakeClassString(
+              'my-1 ml-1 flex items-center rounded-3xl border border-black px-2',
+              typeColor[item.dataType].bg,
+            )
+          "
+          :title="item.name + (item.dataType === 'kyast' ? '（' + item.kyaraStyle + '）' : '')"
+        >
+          <div class="max-w-52 truncate">{{ item.name }}</div>
+          <div class="max-w-40 truncate" v-if="item.dataType === 'kyast'">
+            {{ '（' + item.kyaraStyle + '）' }}
+          </div>
+        </div>
+        <MaterialIcons classString="w-5" icon="ArrowForward400024" />
+        <div class="my-1 ml-1 rounded-3xl border border-black px-2">
+          {{ item.tatieSituation === 'waitTatieUUID' ? '待機中' : '会話中' }}
         </div>
       </div>
-      <MaterialIcons classString="w-5" icon="ArrowForward400024" />
-      <div class="my-1 ml-1 rounded-3xl border border-black px-2">
-        {{ item.tatieSituation === 'waitTatieUUID' ? '待機中' : '会話中' }}
-      </div>
+    </div>
+    <div class="mt-1 flex justify-end px-2">
+      <button
+        @click="() => TatieOrderNew()"
+        title="立ち絵が設定されているキャラ設定の追加（立ち絵が設定されていないと追加できません）"
+        class="h-9 w-9"
+      >
+        <MaterialIcons icon="AddCircle" />
+      </button>
     </div>
   </div>
 </template>

--- a/src/components/setTatieOrder.vue
+++ b/src/components/setTatieOrder.vue
@@ -7,6 +7,7 @@ const props = defineProps<{
   fileListTatie: fileListTatieType[]
   inputProfileUUID: string
   tatieOrderList: tatieOrderListType[]
+  isFileTatieOrderSetting: boolean
   TatieOrderDragStart: (index: number) => void
   TatieOrderDragMove: (index: number) => void
   TatieOrderNew: () => void
@@ -51,7 +52,7 @@ const OpenSelectDisplayTatieOrderKyara = (uuid: string, name: string, style?: st
 
 <template>
   <div class="h-full w-full">
-    <div class="flex h-full w-full flex-col items-center overflow-y-scroll border border-gray-500 px-2 py-1">
+    <div class="relative flex h-full w-full flex-col items-center overflow-y-scroll border border-gray-500 px-2 py-1">
       <div
         class="mt-1 flex w-[580px] justify-between rounded-xl border border-black"
         v-for="(item, index) in tatieOrderList"
@@ -90,12 +91,34 @@ const OpenSelectDisplayTatieOrderKyara = (uuid: string, name: string, style?: st
           <MaterialIcons icon="Delete" />
         </button>
       </div>
+      <!-- 表示のみの場合は上にかぶせて操作できないようにする -->
+      <div
+        class="absolute h-full w-full bg-gray-600 bg-opacity-40"
+        v-if="!(props.settype === 'tatieOrder' || isFileTatieOrderSetting)"
+      ></div>
     </div>
     <div class="mt-1 flex justify-end px-2">
       <button
+        @click="
+          () => (dateList[selectKyara].fileTatieOrderList.active = !dateList[selectKyara].fileTatieOrderList.active)
+        "
+        :title="
+          dateList[selectKyara].fileTatieOrderList.active
+            ? '個別の立ち絵配置設定を無効化'
+            : '個別の立ち絵配置設定を有効化'
+        "
+        class="mr-2 h-9 w-9 rounded-md border border-black"
+        v-if="settype === 'seid'"
+      >
+        <MaterialIcons
+          :classString="dateList[selectKyara].fileTatieOrderList.active === false ? 'opacity-50' : ''"
+          :icon="dateList[selectKyara].fileTatieOrderList.active ? 'RadioButtonChecked' : 'RadioButtonUnchecked'"
+        />
+      </button>
+      <button
         @click="() => TatieOrderNew()"
-        title="立ち絵が設定されているキャラ設定の追加（立ち絵が設定されていないと追加できません）"
-        class="h-9 w-9"
+        title="立ち絵が設定されているキャラ設定の追加（立ち絵が設定されているものが優先的に追加されます）"
+        class="h-9 w-9 rounded-md border border-black"
       >
         <MaterialIcons icon="AddCircle" />
       </button>

--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -60,6 +60,11 @@ export const typeColor: { [key: string]: { bg: string; hoverBG: string; hoverTex
     hoverBG: 'bg-orange-500',
     hoverText: 'text-gray-200',
   },
+  tatieOrder: {
+    bg: 'bg-indigo-300',
+    hoverBG: 'bg-indigo-500',
+    hoverText: 'text-gray-100',
+  },
 }
 
 // 立ち絵の項目リスト

--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -65,6 +65,7 @@ export const typeColor: { [key: string]: { bg: string; hoverBG: string; hoverTex
 // 立ち絵の項目リスト
 export const tatieSettingList = [
   'tatiePath',
+  'waitTatiePath',
   'moviW',
   'moviH',
   'tatieConp',

--- a/src/main.ts
+++ b/src/main.ts
@@ -504,13 +504,20 @@ ipcMain.on(
 // 動画のエンコードを行う
 ipcMain.handle(
   'enterEncodeVideoData',
-  async (event: IpcMainEvent, dirPathName: string, outJsonData: string, infoSettingJsonData: string) => {
+  async (
+    event: IpcMainEvent,
+    dirPathName: string,
+    outJsonData: string,
+    outTatieState: { outJsonData: string; tatieSituation: string }[],
+    infoSettingJsonData: string,
+  ) => {
     // 全体設定を読み込んで、コマンドのパス情報を取得する。
     const globalSettingData: globalSettingExportType = JSON.parse(readJsonData(globalSettingFilePathGLB))
 
     return await enterEncodeVideoData(
       dirPathName,
       outJsonData,
+      outTatieState,
       infoSettingJsonData,
       kyaraTatieDirPathGLB,
       globalSettingData.globalSetting,

--- a/src/main.ts
+++ b/src/main.ts
@@ -502,12 +502,21 @@ ipcMain.on(
 )
 
 // 動画のエンコードを行う
-ipcMain.handle('enterEncodeVideoData', async (event: IpcMainEvent, dirPathName: string, outJsonData: string) => {
-  // 全体設定を読み込んで、コマンドのパス情報を取得する。
-  const globalSettingData: globalSettingExportType = JSON.parse(readJsonData(globalSettingFilePathGLB))
+ipcMain.handle(
+  'enterEncodeVideoData',
+  async (event: IpcMainEvent, dirPathName: string, outJsonData: string, infoSettingJsonData: string) => {
+    // 全体設定を読み込んで、コマンドのパス情報を取得する。
+    const globalSettingData: globalSettingExportType = JSON.parse(readJsonData(globalSettingFilePathGLB))
 
-  return await enterEncodeVideoData(dirPathName, outJsonData, kyaraTatieDirPathGLB, globalSettingData.globalSetting)
-})
+    return await enterEncodeVideoData(
+      dirPathName,
+      outJsonData,
+      infoSettingJsonData,
+      kyaraTatieDirPathGLB,
+      globalSettingData.globalSetting,
+    )
+  },
+)
 
 // 画像エンコードのみを実施し、作成した画像ファイルとファイルパスを返す。
 ipcMain.on(

--- a/src/main.ts
+++ b/src/main.ts
@@ -286,6 +286,7 @@ ipcMain.on('loadKyaraProfileData', async (event: IpcMainEvent, file: string) => 
       const inputData: profileKyaraExportType = JSON.parse(await loadKyaraProfileData(defoKyaraSettingFilePath))
       event.returnValue = {
         infoSetting: inputData.infoSetting,
+        tatieOrderList: inputData.tatieOrderList,
         settingList: inputData.settingList,
       }
     } else {
@@ -294,6 +295,7 @@ ipcMain.on('loadKyaraProfileData', async (event: IpcMainEvent, file: string) => 
   } catch (e) {
     event.returnValue = {
       infoSetting: createDefoInfoDateList(),
+      tatieOrderList: [],
       settingList: <outSettingType[]>[],
     }
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -104,7 +104,7 @@ const createWindow = () => {
 
   // Create the browser window.
   const mainWindow = new BrowserWindow({
-    width: 960,
+    width: 1060,
     height: 885,
     resizable: false, // ウィンドウサイズ変更不可
     useContentSize: true,

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,6 +24,7 @@ import {
   loadSubTextStringList,
   loadGlobalSettingData,
   loadKyaraProfileData,
+  loadVoiceFileData,
 } from './utils/analysisMain'
 import { createDefoInfoDateList } from './utils/analysisGeneral'
 import { outSettingType, profileKyaraExportType, globalSettingExportType } from './type/data-type'
@@ -317,7 +318,7 @@ ipcMain.on('saveKyaraProfileData', async (event: IpcMainEvent, fileName: string,
 
 // 音声ファイルの個別設定データの読み込みを行う
 ipcMain.on('loadVoiceFileData', async (event: IpcMainEvent, dirPathName: string) => {
-  event.returnValue = readJsonData(path.join(dirPathName, 'yomVoiceSetting'))
+  event.returnValue = await loadVoiceFileData(path.join(dirPathName, 'yomVoiceSetting'))
 })
 
 // 音声ファイルの個別設定データの書き込みを行う

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,7 @@ import {
   loadSubTextString,
   loadSubTextStringList,
   loadGlobalSettingData,
+  loadKyaraProfileData,
 } from './utils/analysisMain'
 import { createDefoInfoDateList } from './utils/analysisGeneral'
 import { outSettingType, profileKyaraExportType, globalSettingExportType } from './type/data-type'
@@ -281,7 +282,7 @@ ipcMain.on('loadKyaraProfileData', async (event: IpcMainEvent, file: string) => 
   // 取得に失敗した場合はデフォルトデータを作成する
   try {
     if (fs.existsSync(defoKyaraSettingFilePath + '.json')) {
-      const inputData: profileKyaraExportType = JSON.parse(readJsonData(defoKyaraSettingFilePath))
+      const inputData: profileKyaraExportType = JSON.parse(await loadKyaraProfileData(defoKyaraSettingFilePath))
       event.returnValue = {
         infoSetting: inputData.infoSetting,
         settingList: inputData.settingList,

--- a/src/main.ts
+++ b/src/main.ts
@@ -508,12 +508,15 @@ ipcMain.handle('enterEncodeVideoData', async (event: IpcMainEvent, dirPathName: 
 })
 
 // 画像エンコードのみを実施し、作成した画像ファイルとファイルパスを返す。
-ipcMain.on('loadEncodePicFileData', async (event: IpcMainEvent, outJsonData: string) => {
-  // 全体設定を読み込んで、コマンドのパス情報を取得する。
-  const globalSettingData: globalSettingExportType = JSON.parse(readJsonData(globalSettingFilePathGLB))
+ipcMain.on(
+  'loadEncodePicFileData',
+  async (event: IpcMainEvent, outState: { outJsonData: string; tatieSituation: string }[]) => {
+    // 全体設定を読み込んで、コマンドのパス情報を取得する。
+    const globalSettingData: globalSettingExportType = JSON.parse(readJsonData(globalSettingFilePathGLB))
 
-  event.returnValue = await enterEncodePicFileData(outJsonData, kyaraTatieDirPathGLB, globalSettingData.globalSetting)
-})
+    event.returnValue = await enterEncodePicFileData(outState, kyaraTatieDirPathGLB, globalSettingData.globalSetting)
+  },
+)
 
 // 画像エンコードで作成したファイルを保存する処理を実行
 ipcMain.handle(

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -56,8 +56,12 @@ contextBridge.exposeInMainWorld('yomAPI', {
   writeFileListKyaraData: (outJsonData: string): boolean => {
     return ipcRenderer.sendSync('saveFileListKyaraData', outJsonData)
   },
-  enterEncodeVideoData: async (dirPathName: string, outJsonData: string): Promise<string> => {
-    return await ipcRenderer.invoke('enterEncodeVideoData', dirPathName, outJsonData)
+  enterEncodeVideoData: async (
+    dirPathName: string,
+    outJsonData: string,
+    infoSettingJsonData: string,
+  ): Promise<string> => {
+    return await ipcRenderer.invoke('enterEncodeVideoData', dirPathName, outJsonData, infoSettingJsonData)
   },
   getGlobalSettingData: (): string => {
     return ipcRenderer.sendSync('loadGlobalSettingData')

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -72,8 +72,10 @@ contextBridge.exposeInMainWorld('yomAPI', {
   writeJsonFileData: (fileType: string, outJsonData: string, fileName?: string): boolean => {
     return ipcRenderer.sendSync('saveJsonString', fileType, outJsonData, fileName)
   },
-  getEncodePicFileData: (outJsonData: string): { buffer: Uint8Array; path: string } => {
-    return ipcRenderer.sendSync('loadEncodePicFileData', outJsonData)
+  getEncodePicFileData: (
+    outState: { outJsonData: string; tatieSituation: string }[],
+  ): { buffer: Uint8Array; path: string } => {
+    return ipcRenderer.sendSync('loadEncodePicFileData', outState)
   },
   writeUint8ArrayFileData: async (
     fileData: Uint8Array,

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -59,9 +59,16 @@ contextBridge.exposeInMainWorld('yomAPI', {
   enterEncodeVideoData: async (
     dirPathName: string,
     outJsonData: string,
+    outTatieState: { outJsonData: string; tatieSituation: string }[],
     infoSettingJsonData: string,
   ): Promise<string> => {
-    return await ipcRenderer.invoke('enterEncodeVideoData', dirPathName, outJsonData, infoSettingJsonData)
+    return await ipcRenderer.invoke(
+      'enterEncodeVideoData',
+      dirPathName,
+      outJsonData,
+      outTatieState,
+      infoSettingJsonData,
+    )
   },
   getGlobalSettingData: (): string => {
     return ipcRenderer.sendSync('loadGlobalSettingData')

--- a/src/type/data-type.ts
+++ b/src/type/data-type.ts
@@ -164,6 +164,7 @@ export type profileKyaraExportType = {
   softVer: [number, number, number] // バージョン番号を数値の配列にする
   exportStatus: number // 出力エラーがあると0ではなくなる（増える）
   infoSetting: infoSettingType
+  tatieOrderList: tatieOrderListType[]
   settingList: outSettingType[]
 }
 
@@ -178,6 +179,7 @@ export type profileVoiceFileExportType = {
 // JSONファイルから読み込んだデータをメインからレンダラー側へ送るためのType
 export type inputProfileSendReType = {
   infoSetting: infoSettingType
+  tatieOrderList: tatieOrderListType[]
   settingList: outSettingType[]
 }
 

--- a/src/type/data-type.ts
+++ b/src/type/data-type.ts
@@ -271,6 +271,7 @@ export type pathStatusType = {
 export type tatieOrderListType = {
   uuid: string
   dataType: dataTextType
+  settingUUID: string
   name: string
   kyaraStyle: string
   tatieSituation: tatieSituationType

--- a/src/type/data-type.ts
+++ b/src/type/data-type.ts
@@ -183,12 +183,6 @@ export type inputProfileSendReType = {
   settingList: outSettingType[]
 }
 
-// メイン側にエンコードするファイルの情報を送るType
-export type encodeProfileSendReType = {
-  infoSetting: infoSettingType
-  settingList: outSettingType
-}
-
 // 立ち絵のファイルUUIDとそのファイル名のリストを作るためのType
 export type fileListTatieType = {
   uuid: string

--- a/src/type/data-type.ts
+++ b/src/type/data-type.ts
@@ -98,10 +98,13 @@ export type subtitleSettingType =
   | 'subSideSpaceSize'
 
 // 情報タイプを指定
-export type dataTextType = 'defo' | 'kyara' | 'kyast' | 'seid'
+export type dataTextType = 'defo' | 'kyara' | 'kyast' | 'seid' | 'tatieOrder'
 
 // 「基本情報」「立ち絵」「字幕」のどれか
-export type selectedEditDataType = 'defo' | 'tatie' | 'subtitle'
+export type selectedEditDataType = 'defo' | 'tatie' | 'subtitle' | 'tatieOrder'
+
+// 立ち絵の会話中と待機中のUUIDが入った連想配列名
+export type tatieSituationType = 'tatieUUID' | 'waitTatieUUID'
 
 // 立ち絵の配置位置
 export type tatieSideType =
@@ -260,4 +263,13 @@ export type pathStatusType = {
   dirname: string // 親ディレクトリ名
   basename: string // ファイル名
   extname: string // 拡張子
+}
+
+// 立ち絵の表示順番を記録する配列の型
+export type tatieOrderListType = {
+  uuid: string
+  dataType: dataTextType
+  name: string
+  kyaraStyle: string
+  tatieSituation: tatieSituationType
 }

--- a/src/type/data-type.ts
+++ b/src/type/data-type.ts
@@ -164,6 +164,14 @@ export type profileKyaraExportType = {
   settingList: outSettingType[]
 }
 
+// 音声ファイルの個別設定データをJSONファルに出力するために、
+// 出力時のソフトのバージョンと出力エラーの有無を記録するType
+export type profileVoiceFileExportType = {
+  softVer: [number, number, number] // バージョン番号を数値の配列にする
+  exportStatus: number // 出力エラーがあると0ではなくなる（増える）
+  settingList: outSettingType[]
+}
+
 // JSONファイルから読み込んだデータをメインからレンダラー側へ送るためのType
 export type inputProfileSendReType = {
   infoSetting: infoSettingType

--- a/src/type/data-type.ts
+++ b/src/type/data-type.ts
@@ -65,6 +65,11 @@ export type statusSubAlignment = {
   active: boolean
 }
 
+export type statusTatieOrderList = {
+  val: tatieOrderListType[]
+  active: boolean
+}
+
 // 立ち絵の項目のタイプ
 export type tatieSettingType =
   | 'tatieUUID'
@@ -141,6 +146,7 @@ export type outSettingType = {
   fileName: string // ファイル名（拡張子なし）(seidの音声ファイル用)
   fileExtension: string // ファイル拡張子     (seidの音声ファイル用)
   voiceID: string // ID                       (seidの音声ファイル用)
+  fileTatieOrderList: statusTatieOrderList // 複数立ち絵の表示順番を記録          (seidの音声ファイル用)
 }
 
 // 各情報タイプで選択していたキャラのID情報を記録

--- a/src/type/data-type.ts
+++ b/src/type/data-type.ts
@@ -1,6 +1,7 @@
 // 立ち絵関連の設定
 export type tatieSetting = {
   tatieUUID: statusString // 立ち絵のUUID
+  waitTatieUUID: statusString // 待機中の立ち絵のUUID
   moviW: statusNumber // 画面の横
   moviH: statusNumber // 画面の縦
   tatieConp: statusBoolean // 立ち絵の加工をするか
@@ -67,6 +68,7 @@ export type statusSubAlignment = {
 // 立ち絵の項目のタイプ
 export type tatieSettingType =
   | 'tatieUUID'
+  | 'waitTatieUUID'
   | 'moviW'
   | 'moviH'
   | 'tatieConp'

--- a/src/utils/analysisData.ts
+++ b/src/utils/analysisData.ts
@@ -8,8 +8,6 @@ import {
   fileListTatieType,
   tatieSetting,
   subtitleSetting,
-  infoSettingType,
-  encodeProfileSendReType,
   globalSettingExportType,
   globalSettingType,
   inputProfileSendReType,
@@ -289,12 +287,7 @@ export const createNewFileListTatie = (uuid: string, fileName?: string, kyaraNam
 }
 
 // 指定された音声ファイルについて、優先設定を取得・整理して変換用コマンドに渡す情報を作成する。
-export const createVoiceFileEncodeSetting = (
-  fileSetting: outSettingType,
-  index: number,
-  dateList: outSettingType[],
-  infoData: infoSettingType,
-): encodeProfileSendReType => {
+export const createVoiceFileEncodeSetting = (index: number, dateList: outSettingType[]): outSettingType => {
   // 結果を格納する連想配列を作成
   const outDataTatie = ref<tatieSetting>({
     tatieUUID: { val: '', active: false },
@@ -364,52 +357,49 @@ export const createVoiceFileEncodeSetting = (
   }
 
   // 結果を出力する
-  return {
-    infoSetting: infoData,
-    settingList: createNewDateList(
-      fileSetting.dataType,
-      fileSetting.uuid,
-      fileSetting.name,
-      fileSetting.kyaraStyle,
-      {
-        tatieUUID: outDataTatie.value.tatieUUID.val,
-        waitTatieUUID: outDataTatie.value.waitTatieUUID.val,
-        moviW: outDataTatie.value.moviW.val,
-        moviH: outDataTatie.value.moviH.val,
-        tatieConp: outDataTatie.value.tatieConp.val,
-        tatieSide: outDataTatie.value.tatieSide.val,
-        tatieHpx: outDataTatie.value.tatieHpx.val,
-        tatiePwPs: outDataTatie.value.tatiePwPs.val,
-        tatiePhPs: outDataTatie.value.tatiePhPs.val,
-        fps: outDataTatie.value.fps.val,
-      },
-      {
-        subText: outDataSubtitle.value.subText.val,
-        fontsPath: outDataSubtitle.value.fontsPath.val,
-        subAlignment: outDataSubtitle.value.subAlignment.val,
-        subAutoRt: outDataSubtitle.value.subAutoRt.val,
-        subTextBord: outDataSubtitle.value.subTextBord.val,
-        subBG: outDataSubtitle.value.subBG.val,
-        subSize: outDataSubtitle.value.subSize.val,
-        subTextSpaceSize: outDataSubtitle.value.subTextSpaceSize.val,
-        subColor: outDataSubtitle.value.subColor.val,
-        subOrdercr: outDataSubtitle.value.subOrdercr.val,
-        subBorderW: outDataSubtitle.value.subBorderW.val,
-        subBgcolor: outDataSubtitle.value.subBgcolor.val,
-        subBgTr: outDataSubtitle.value.subBgTr.val,
-        subTextUseVoiceFileName: outDataSubtitle.value.subTextUseVoiceFileName.val,
-        subChangeSta: outDataSubtitle.value.subChangeSta.val,
-        subSideSpaceSize: outDataSubtitle.value.subSideSpaceSize.val,
-        nameTagStringDis: outDataSubtitle.value.nameTagStringDis.val,
-        nameTagString: outDataSubtitle.value.nameTagString.val,
-        nameTagH: outDataSubtitle.value.nameTagH.val,
-        nameTagW: outDataSubtitle.value.nameTagW.val,
-      },
-      fileSetting.fileName,
-      fileSetting.fileExtension,
-      fileSetting.voiceID,
-    ),
-  }
+  return createNewDateList(
+    dateList[index].dataType,
+    dateList[index].uuid,
+    dateList[index].name,
+    dateList[index].kyaraStyle,
+    {
+      tatieUUID: outDataTatie.value.tatieUUID.val,
+      waitTatieUUID: outDataTatie.value.waitTatieUUID.val,
+      moviW: outDataTatie.value.moviW.val,
+      moviH: outDataTatie.value.moviH.val,
+      tatieConp: outDataTatie.value.tatieConp.val,
+      tatieSide: outDataTatie.value.tatieSide.val,
+      tatieHpx: outDataTatie.value.tatieHpx.val,
+      tatiePwPs: outDataTatie.value.tatiePwPs.val,
+      tatiePhPs: outDataTatie.value.tatiePhPs.val,
+      fps: outDataTatie.value.fps.val,
+    },
+    {
+      subText: outDataSubtitle.value.subText.val,
+      fontsPath: outDataSubtitle.value.fontsPath.val,
+      subAlignment: outDataSubtitle.value.subAlignment.val,
+      subAutoRt: outDataSubtitle.value.subAutoRt.val,
+      subTextBord: outDataSubtitle.value.subTextBord.val,
+      subBG: outDataSubtitle.value.subBG.val,
+      subSize: outDataSubtitle.value.subSize.val,
+      subTextSpaceSize: outDataSubtitle.value.subTextSpaceSize.val,
+      subColor: outDataSubtitle.value.subColor.val,
+      subOrdercr: outDataSubtitle.value.subOrdercr.val,
+      subBorderW: outDataSubtitle.value.subBorderW.val,
+      subBgcolor: outDataSubtitle.value.subBgcolor.val,
+      subBgTr: outDataSubtitle.value.subBgTr.val,
+      subTextUseVoiceFileName: outDataSubtitle.value.subTextUseVoiceFileName.val,
+      subChangeSta: outDataSubtitle.value.subChangeSta.val,
+      subSideSpaceSize: outDataSubtitle.value.subSideSpaceSize.val,
+      nameTagStringDis: outDataSubtitle.value.nameTagStringDis.val,
+      nameTagString: outDataSubtitle.value.nameTagString.val,
+      nameTagH: outDataSubtitle.value.nameTagH.val,
+      nameTagW: outDataSubtitle.value.nameTagW.val,
+    },
+    dateList[index].fileName,
+    dateList[index].fileExtension,
+    dateList[index].voiceID,
+  )
 }
 
 // 全体設定を読み込み

--- a/src/utils/analysisData.ts
+++ b/src/utils/analysisData.ts
@@ -156,6 +156,7 @@ export const createNewDateList = (
   kyaraStyle: string,
   tatie?: {
     tatieUUID?: string
+    waitTatieUUID?: string
     moviW?: number
     moviH?: number
     tatieConp?: boolean
@@ -201,6 +202,10 @@ export const createNewDateList = (
       tatieUUID: {
         val: tatie.tatieUUID ?? DEFAULT_KYARA_TATIE_UUID,
         active: tatie.tatieUUID !== undefined ? true : false,
+      },
+      waitTatieUUID: {
+        val: tatie.waitTatieUUID ?? DEFAULT_KYARA_TATIE_UUID,
+        active: tatie.waitTatieUUID !== undefined ? true : false,
       },
       moviW: { val: tatie.moviW ?? 1280, active: tatie.moviW !== undefined ? true : false },
       moviH: { val: tatie.moviH ?? 720, active: tatie.moviH !== undefined ? true : false },
@@ -293,6 +298,7 @@ export const createVoiceFileEncodeSetting = (
   // 結果を格納する連想配列を作成
   const outDataTatie = ref<tatieSetting>({
     tatieUUID: { val: '', active: false },
+    waitTatieUUID: { val: '', active: false },
     moviW: { val: 0, active: false },
     moviH: { val: 0, active: false },
     tatieConp: { val: false, active: false },
@@ -367,6 +373,7 @@ export const createVoiceFileEncodeSetting = (
       fileSetting.kyaraStyle,
       {
         tatieUUID: outDataTatie.value.tatieUUID.val,
+        waitTatieUUID: outDataTatie.value.waitTatieUUID.val,
         moviW: outDataTatie.value.moviW.val,
         moviH: outDataTatie.value.moviH.val,
         tatieConp: outDataTatie.value.tatieConp.val,

--- a/src/utils/analysisData.ts
+++ b/src/utils/analysisData.ts
@@ -13,6 +13,7 @@ import {
   inputProfileSendReType,
   kyaraProfileListExportType,
   kyaraProfileListType,
+  tatieOrderListType,
 } from '../type/data-type'
 import { NowTimeData } from './analysisGeneral'
 import {
@@ -189,6 +190,7 @@ export const createNewDateList = (
   fileName?: string,
   fileExtension?: string,
   voiceID?: string,
+  fileTatieOrderList?: tatieOrderListType[],
   platform?: NodeJS.Platform,
 ): outSettingType => {
   return {
@@ -257,6 +259,7 @@ export const createNewDateList = (
     fileName: fileName !== undefined ? fileName : '',
     fileExtension: fileExtension !== undefined ? fileExtension : '',
     voiceID: voiceID !== undefined ? voiceID : '',
+    fileTatieOrderList: { val: fileTatieOrderList ?? [], active: fileTatieOrderList !== undefined ? true : false },
   }
 }
 
@@ -272,6 +275,7 @@ export const CreateCopyDateList = (kyraData: outSettingType, dataType: dataTextT
     fileName: '',
     fileExtension: '',
     voiceID: '',
+    fileTatieOrderList: { val: [], active: false },
   }
 }
 

--- a/src/utils/analysisFile.ts
+++ b/src/utils/analysisFile.ts
@@ -243,7 +243,7 @@ export const makeTatiePicEncodeList = (
     const encodeList = tatieOrderList.map((e) => {
       // dateListに一致するものを探し、立ち絵の設定をencodeListに入れる。
 
-      const ans = dateList.findIndex((f) => e.dataType + e.name + e.kyaraStyle === f.dataType + f.name + f.kyaraStyle)
+      const ans = dateList.findIndex((f) => e.dataType + e.settingUUID === f.dataType + f.uuid)
       // ただ、会話中のキャラ(selectSetting)含まれている場合は、tatieSituationで指定されている状態の画像を選択させる。
       if (ans !== -1) {
         if (

--- a/src/utils/analysisFile.ts
+++ b/src/utils/analysisFile.ts
@@ -213,9 +213,26 @@ export const enterEncodeTatiePicFile = async (
   tatieOrderList: tatieOrderListType[],
   selectKyara?: number,
 ): Promise<{ buffer: Uint8Array; path: string }> => {
+  return yomAPI.getEncodePicFileData(
+    makeTatiePicEncodeList(tatieSituation, dateList, settype, tatieOrderList, selectKyara),
+  )
+}
+
+// 立ち絵の変換を行う際に、mainに送付するデータを作成する。
+// 複数の立ち絵を表示させる場合にはその内容をまとめて出力する。
+export const makeTatiePicEncodeList = (
+  tatieSituation: string,
+  dateList: outSettingType[],
+  settype: dataTextType,
+  tatieOrderList: tatieOrderListType[],
+  selectKyara?: number,
+): {
+  outJsonData: string
+  tatieSituation: string
+}[] => {
   const selectSetting = selectKyara !== undefined ? createVoiceFileEncodeSetting(selectKyara, dateList) : undefined
 
-  // 変換の実施
+  // データ作成の実施
   if (settype === 'tatieOrder' || settype === 'seid') {
     // seid のときに、selectKyaraのキャラがencodeListに入っているか確認する数値
     let chkSelectKyara = -1
@@ -251,12 +268,10 @@ export const enterEncodeTatiePicFile = async (
 
     console.log('encodeList: ' + encodeList.length)
 
-    return yomAPI.getEncodePicFileData(encodeList)
+    return encodeList
   } else {
     console.log('encodeList ではない: selectSetting: ' + selectSetting.name)
-    return yomAPI.getEncodePicFileData([
-      { outJsonData: JSON.stringify(selectSetting, undefined, 2), tatieSituation: tatieSituation },
-    ])
+    return [{ outJsonData: JSON.stringify(selectSetting, undefined, 2), tatieSituation: tatieSituation }]
   }
 }
 

--- a/src/utils/analysisFile.ts
+++ b/src/utils/analysisFile.ts
@@ -5,6 +5,7 @@ import {
   fileListTatieExportType,
   fileListTatieType,
   encodeProfileSendReType,
+  profileVoiceFileExportType,
 } from '../type/data-type'
 import { ref } from 'vue'
 import { createNewDataID, createNewDateList } from './analysisData'
@@ -27,11 +28,7 @@ export const analysisFileName = (
   const [lists, dir] = yomAPI.opneVoiceFileDir(defoSelectDir)
 
   // ディレクトリに個別設定データの設定ファイルがある場合は取得する
-  const inputData = ref<{
-    softVer: [number, number, number]
-    exportStatus: number
-    settingList: outSettingType[]
-  }>(null)
+  const inputData = ref<profileVoiceFileExportType>(null)
   if (dir !== null) {
     try {
       inputData.value = JSON.parse(yomAPI.getVoiceFileDirData(dir))
@@ -134,7 +131,7 @@ export const writeVoiceFileSettingData = (voiceFileDirPath: string, settingList:
   const softVerData = yomAPI.getSoftVersionData()
 
   // 送付するデータを作成して、JSON形式に変換する
-  const outPrData = {
+  const outPrData: profileVoiceFileExportType = {
     softVer: softVerData.softVer,
     exportStatus: softVerData.exportStatus,
     settingList: settingList,

--- a/src/utils/analysisFile.ts
+++ b/src/utils/analysisFile.ts
@@ -216,22 +216,37 @@ export const enterEncodeTatiePicFile = async (
 
   // 変換の実施
   if (settype === 'tatieOrder' || settype === 'seid') {
+    // seid のときに、selectKyaraのキャラがencodeListに入っているか確認する数値
+    let chkSelectKyara = -1
+
     const encodeList = tatieOrderList.map((e) => {
-      // dateListに一致するものを探す。
+      // dateListに一致するものを探し、立ち絵の設定をencodeListに入れる。
 
       const ans = dateList.findIndex((f) => e.dataType + e.name + e.kyaraStyle === f.dataType + f.name + f.kyaraStyle)
       // ただ、会話中のキャラ(selectSetting)含まれている場合は、tatieSituationで指定されている状態の画像を選択させる。
       if (ans !== -1) {
-        return {
-          outJsonData: JSON.stringify(createVoiceFileEncodeSetting(ans, dateList), undefined, 2),
-          tatieSituation:
-            e.dataType + e.name + e.kyaraStyle ===
-            selectSetting?.dataType + selectSetting?.name + selectSetting?.kyaraStyle
-              ? tatieSituation
-              : e.tatieSituation,
+        if (
+          e.name + (e.dataType === 'kyast' ? e.kyaraStyle : '') ===
+          selectSetting?.name + (e.dataType === 'kyast' ? selectSetting?.kyaraStyle : '')
+        ) {
+          chkSelectKyara = 1
+          return {
+            outJsonData: JSON.stringify(createVoiceFileEncodeSetting(ans, dateList), undefined, 2),
+            tatieSituation: tatieSituation,
+          }
+        } else {
+          return {
+            outJsonData: JSON.stringify(createVoiceFileEncodeSetting(ans, dateList), undefined, 2),
+            tatieSituation: e.tatieSituation,
+          }
         }
       }
     })
+
+    // seid のときに、encodeListにselectSettingのキャラがない場合は追加する
+    if (settype === 'seid' && chkSelectKyara !== 1) {
+      encodeList.unshift({ outJsonData: JSON.stringify(selectSetting, undefined, 2), tatieSituation: tatieSituation })
+    }
 
     console.log('encodeList: ' + encodeList.length)
 

--- a/src/utils/analysisFile.ts
+++ b/src/utils/analysisFile.ts
@@ -4,7 +4,6 @@ import {
   profileKyaraExportType,
   fileListTatieExportType,
   fileListTatieType,
-  encodeProfileSendReType,
   profileVoiceFileExportType,
   tatieOrderListType,
 } from '../type/data-type'
@@ -190,25 +189,32 @@ export const writeFileListKyaraData = (settingList: fileListTatieType[]): boolea
 // 指定された音声ファイルの変換を行う。
 export const enterEncodeVideoFile = async (
   voiceFileDirPath: string,
-  encodeSetting: encodeProfileSendReType,
+  encodeSetting: outSettingType,
+  infoSetting: infoSettingType,
 ): Promise<string> => {
   // JSONファイルへの変換
   const outJsonData = JSON.stringify(encodeSetting, undefined, 2)
 
   // 変換の実施
-  return yomAPI.enterEncodeVideoData(voiceFileDirPath, outJsonData)
+  return yomAPI.enterEncodeVideoData(
+    voiceFileDirPath,
+    JSON.stringify(encodeSetting, undefined, 2),
+    JSON.stringify(infoSetting, undefined, 2),
+  )
 }
 
 // 指定された立ち絵ファイルの変換を行う。
 export const enterEncodeTatiePicFile = async (
-  encodeSetting: encodeProfileSendReType,
+  encodeSetting: outSettingType,
   tatieSituation: string,
 ): Promise<{ buffer: Uint8Array; path: string }> => {
   // JSONファイルへの変換
   const outJsonData = JSON.stringify(encodeSetting, undefined, 2)
 
   // 変換の実施
-  return yomAPI.getEncodePicFileData([{ outJsonData: outJsonData, tatieSituation: tatieSituation }])
+  return yomAPI.getEncodePicFileData([
+    { outJsonData: JSON.stringify(encodeSetting, undefined, 2), tatieSituation: tatieSituation },
+  ])
 }
 
 // 変換された立ち絵ファイルを保存する。

--- a/src/utils/analysisFile.ts
+++ b/src/utils/analysisFile.ts
@@ -200,6 +200,7 @@ export const enterEncodeVideoFile = async (
   return yomAPI.enterEncodeVideoData(
     voiceFileDirPath,
     JSON.stringify(encodeSetting, undefined, 2),
+    [{ outJsonData: JSON.stringify(encodeSetting, undefined, 2), tatieSituation: 'tatieUUID' }],
     JSON.stringify(infoSetting, undefined, 2),
   )
 }

--- a/src/utils/analysisFile.ts
+++ b/src/utils/analysisFile.ts
@@ -6,6 +6,7 @@ import {
   fileListTatieType,
   encodeProfileSendReType,
   profileVoiceFileExportType,
+  tatieOrderListType,
 } from '../type/data-type'
 import { ref } from 'vue'
 import { createNewDataID, createNewDateList } from './analysisData'
@@ -104,6 +105,7 @@ export const analysisFileName = (
 export const writeProfilleSettingData = (
   profilleName: string,
   infoSetting: infoSettingType,
+  tatieOrderList: tatieOrderListType[],
   settingList: outSettingType[],
 ): boolean => {
   console.log(profilleName)
@@ -116,6 +118,7 @@ export const writeProfilleSettingData = (
     softVer: softVerData.softVer,
     exportStatus: softVerData.exportStatus,
     infoSetting: infoSetting,
+    tatieOrderList: tatieOrderList,
     settingList: settingList,
   }
   const outJsonData = JSON.stringify(outPrData, undefined, 2)

--- a/src/utils/analysisFile.ts
+++ b/src/utils/analysisFile.ts
@@ -90,6 +90,7 @@ export const analysisFileName = (
               fileName,
               fileExtension,
               voiceID,
+              [],
               yomAPI.getPlatformData(),
             ),
           )

--- a/src/utils/analysisFile.ts
+++ b/src/utils/analysisFile.ts
@@ -199,12 +199,13 @@ export const enterEncodeVideoFile = async (
 // 指定された立ち絵ファイルの変換を行う。
 export const enterEncodeTatiePicFile = async (
   encodeSetting: encodeProfileSendReType,
+  tatieSituation: string,
 ): Promise<{ buffer: Uint8Array; path: string }> => {
   // JSONファイルへの変換
   const outJsonData = JSON.stringify(encodeSetting, undefined, 2)
 
   // 変換の実施
-  return yomAPI.getEncodePicFileData(outJsonData)
+  return yomAPI.getEncodePicFileData([{ outJsonData: outJsonData, tatieSituation: tatieSituation }])
 }
 
 // 変換された立ち絵ファイルを保存する。

--- a/src/utils/analysisFile.ts
+++ b/src/utils/analysisFile.ts
@@ -7,6 +7,7 @@ import {
   profileVoiceFileExportType,
   tatieOrderListType,
   dataTextType,
+  tatieSituationType,
 } from '../type/data-type'
 import { ref } from 'vue'
 import { createNewDataID, createNewDateList, createVoiceFileEncodeSetting } from './analysisData'
@@ -190,17 +191,18 @@ export const writeFileListKyaraData = (settingList: fileListTatieType[]): boolea
 // 指定された音声ファイルの変換を行う。
 export const enterEncodeVideoFile = async (
   voiceFileDirPath: string,
-  encodeSetting: outSettingType,
+  selectKyara: number,
   infoSetting: infoSettingType,
+  tatieSituation: tatieSituationType,
+  dateList: outSettingType[],
+  settype: dataTextType,
+  tatieOrderList: tatieOrderListType[],
 ): Promise<string> => {
-  // JSONファイルへの変換
-  const outJsonData = JSON.stringify(encodeSetting, undefined, 2)
-
   // 変換の実施
   return yomAPI.enterEncodeVideoData(
     voiceFileDirPath,
-    JSON.stringify(encodeSetting, undefined, 2),
-    [{ outJsonData: JSON.stringify(encodeSetting, undefined, 2), tatieSituation: 'tatieUUID' }],
+    JSON.stringify(dateList[selectKyara], undefined, 2),
+    makeTatiePicEncodeList(tatieSituation, dateList, settype, tatieOrderList, selectKyara),
     JSON.stringify(infoSetting, undefined, 2),
   )
 }

--- a/src/utils/analysisGeneral.ts
+++ b/src/utils/analysisGeneral.ts
@@ -36,6 +36,7 @@ export const createDefoKyaraDateList = (platform?: NodeJS.Platform): outSettingT
     undefined,
     {
       tatieUUID: DEFAULT_KYARA_TATIE_UUID,
+      waitTatieUUID: DEFAULT_KYARA_TATIE_UUID,
       moviW: 1280,
       moviH: 720,
       tatieConp: true,

--- a/src/utils/analysisMain.ts
+++ b/src/utils/analysisMain.ts
@@ -25,6 +25,7 @@ import {
   globalSettingExportTempType,
   globalSettingExportV021Type,
   globalSettingV021Type,
+  profileVoiceFileExportType,
 } from '../type/data-type'
 import { DEFAULT_KYARA_PROFILE_NAME, DEFAULT_KYARA_TATIE_UUID } from '../data/data'
 import { createNewDateList } from './analysisData'
@@ -726,6 +727,76 @@ export const loadKyaraProfileData = async (confPath: string): Promise<string> =>
           softVar: out.softVer,
           exportStatus: out.exportStatus,
           infoSetting: inputJsonData.infoSetting,
+          settingList: result,
+        },
+        undefined,
+        2,
+      )
+    })
+    .then((result: string) => {
+      return writeJsonData(confPath, result)
+    })
+    .then(() => {
+      console.log('再読込')
+      jsonData.value = readJsonData(confPath)
+    })
+    .catch(() => {
+      console.log('問題なし')
+    })
+
+  return jsonData.value
+}
+
+// 音声ファイルの個別設定データを読み込み、 設定が古い場合は、内容を更新する。
+export const loadVoiceFileData = async (confPath: string): Promise<string> => {
+  const jsonData = ref<string>(readJsonData(confPath))
+
+  const inputJsonData: profileVoiceFileExportType = JSON.parse(jsonData.value)
+
+  ///////
+  // 古い設定ファイルだった場合、必要な項目を追加します。
+
+  // var 0.2 以下の場合
+  // waitTatieUUID がないので追加する
+  await new Promise((resolve, reject) => {
+    if (inputJsonData.softVer[0] <= 0 && inputJsonData.softVer[1] <= 2) {
+      console.log('var 0.2 以下の場合')
+      resolve('waitTatieUUID')
+    } else {
+      reject()
+    }
+  })
+    .then(() => {
+      console.log('waitTatieUUID を追加')
+      const ans: outSettingType[] = inputJsonData.settingList.map((item) => {
+        return {
+          dataType: item.dataType,
+          uuid: item.uuid,
+          name: item.name,
+          kyaraStyle: item.kyaraStyle,
+          tatie: {
+            ...item.tatie,
+            waitTatieUUID: {
+              val: DEFAULT_KYARA_TATIE_UUID,
+              active: false,
+            },
+          },
+          subtitle: item.subtitle,
+          fileName: item.fileName,
+          fileExtension: item.fileExtension,
+          voiceID: item.voiceID,
+        }
+      })
+      return ans
+    })
+    .then((result: outSettingType[]) => {
+      console.log('追加したデータを書き込む')
+      // 追加したデータを書き込む
+      const out = outSoftVersion()
+      return JSON.stringify(
+        {
+          softVar: out.softVer,
+          exportStatus: out.exportStatus,
           settingList: result,
         },
         undefined,

--- a/src/utils/analysisMain.ts
+++ b/src/utils/analysisMain.ts
@@ -453,35 +453,31 @@ export const enterEncodePicFileData = async (
   const tempDirPath = await createTempDir()
 
   console.log('長さ; ' + outState.length)
-  if (outState[0].outJsonData === undefined) {
-    // 立ち絵がない場合はnullのデータを返す。
-    return {
-      buffer: null,
-      path: 'NoFile',
-    }
-  }
 
   const imgList: string[] = []
   let kazu = 0
   for (const item of outState) {
-    const setting: outSettingType = JSON.parse(item.outJsonData)
-    console.log('変換: ' + setting.name + ', ' + kazu)
-    if (fs.existsSync(path.join(kyaraTatieDirPath, setting.tatie.tatieUUID.val + '.png'))) {
-      //// 画像ファイルの作成
+    // outJsonDataの中身があるか確認して処理を実行する。
+    if (item.outJsonData !== undefined) {
+      const setting: outSettingType = JSON.parse(item.outJsonData)
+      console.log('変換: ' + setting.name + ', ' + kazu)
+      if (fs.existsSync(path.join(kyaraTatieDirPath, setting.tatie.tatieUUID.val + '.png'))) {
+        //// 画像ファイルの作成
 
-      // 画像ファイルの作成を実行
-      imgList.push(
-        await enterEncodeImageData(
-          setting,
-          item.tatieSituation,
-          tempDirPath,
-          globalSetting.exeFilePath.convert,
-          kyaraTatieDirPath,
-          tempDirPath,
-          'tb_' + kazu,
-        ),
-      )
-      kazu += 1
+        // 画像ファイルの作成を実行
+        imgList.push(
+          await enterEncodeImageData(
+            setting,
+            item.tatieSituation,
+            tempDirPath,
+            globalSetting.exeFilePath.convert,
+            kyaraTatieDirPath,
+            tempDirPath,
+            'tb_' + kazu,
+          ),
+        )
+        kazu += 1
+      }
     }
   }
 

--- a/src/utils/analysisMain.ts
+++ b/src/utils/analysisMain.ts
@@ -25,6 +25,7 @@ import {
   globalSettingExportV021Type,
   globalSettingV021Type,
   profileVoiceFileExportType,
+  tatieOrderListType,
 } from '../type/data-type'
 import { DEFAULT_KYARA_PROFILE_NAME, DEFAULT_KYARA_TATIE_UUID } from '../data/data'
 import { createNewDateList } from './analysisData'
@@ -213,6 +214,7 @@ export const initializationSetting = (): profileKyaraExportType => {
         '',
         '',
         '',
+        [],
         process.platform,
       ),
     )
@@ -221,7 +223,7 @@ export const initializationSetting = (): profileKyaraExportType => {
     if (e.kyaraStyle !== undefined) {
       e.kyaraStyle.map((ekyaraStyle) =>
         outData.value.push(
-          createNewDateList('kyast', makeUUID(), e.kyaraName, ekyaraStyle, {}, {}, '', '', '', process.platform),
+          createNewDateList('kyast', makeUUID(), e.kyaraName, ekyaraStyle, {}, {}, '', '', '', [], process.platform),
         ),
       )
     }
@@ -728,6 +730,7 @@ export const loadKyaraProfileData = async (confPath: string): Promise<string> =>
     .then(() => {
       // 追加したデータを書き込む
       const out = outSoftVersion()
+      const tatieOrder: tatieOrderListType[] = []
       return JSON.stringify(
         {
           softVar: out.softVer,
@@ -751,6 +754,7 @@ export const loadKyaraProfileData = async (confPath: string): Promise<string> =>
               fileName: item.fileName,
               fileExtension: item.fileExtension,
               voiceID: item.voiceID,
+              fileTatieOrderList: { val: tatieOrder, active: false },
             }
           }),
         },
@@ -794,6 +798,7 @@ export const loadVoiceFileData = async (confPath: string): Promise<string> => {
     .then(() => {
       // 追加したデータを書き込む
       const out = outSoftVersion()
+      const tatieOrder: tatieOrderListType[] = []
       return JSON.stringify(
         {
           softVar: out.softVer,
@@ -815,6 +820,7 @@ export const loadVoiceFileData = async (confPath: string): Promise<string> => {
               fileName: item.fileName,
               fileExtension: item.fileExtension,
               voiceID: item.voiceID,
+              fileTatieOrderList: { val: tatieOrder, active: false },
             }
           }),
         },

--- a/src/utils/analysisMain.ts
+++ b/src/utils/analysisMain.ts
@@ -458,7 +458,7 @@ export const enterEncodePicFileData = async (
   let kazu = 0
   for (const item of outState) {
     // outJsonDataの中身があるか確認して処理を実行する。
-    if (item.outJsonData !== undefined) {
+    if (item?.outJsonData !== undefined) {
       const setting: outSettingType = JSON.parse(item.outJsonData)
       console.log('変換: ' + setting.name + ', ' + kazu)
       if (fs.existsSync(path.join(kyaraTatieDirPath, setting.tatie.tatieUUID.val + '.png'))) {

--- a/src/utils/analysisMain.ts
+++ b/src/utils/analysisMain.ts
@@ -650,18 +650,18 @@ export const loadGlobalSettingData = async (confPath: string): Promise<string> =
     }
   })
     .then((result: globalSettingV021Type) => {
-      console.log('useSubText を追加')
-      return {
-        ...result,
-        useSubText: true,
-      }
-    })
-    .then((result: globalSettingType) => {
       console.log('追加したデータを書き込む')
       // 追加したデータを書き込む
       const out = outSoftVersion()
       return JSON.stringify(
-        { exportStatus: out.exportStatus, softVar: out.softVer, globalSetting: result },
+        {
+          exportStatus: out.exportStatus,
+          softVar: out.softVer,
+          globalSetting: {
+            ...result,
+            useSubText: true,
+          },
+        },
         undefined,
         2,
       )
@@ -690,7 +690,7 @@ export const loadKyaraProfileData = async (confPath: string): Promise<string> =>
   // 古い設定ファイルだった場合、必要な項目を追加します。
 
   // var 0.2 以下の場合
-  // waitTatieUUID がないので追加する
+  // waitTatieUUID と tatieOrderList がないので追加する
   await new Promise((resolve, reject) => {
     if (inputJsonData.softVer[0] <= 0 && inputJsonData.softVer[1] <= 2) {
       console.log('var 0.2 以下の場合')
@@ -700,30 +700,6 @@ export const loadKyaraProfileData = async (confPath: string): Promise<string> =>
     }
   })
     .then(() => {
-      console.log('waitTatieUUID を追加')
-      const ans: outSettingType[] = inputJsonData.settingList.map((item) => {
-        return {
-          dataType: item.dataType,
-          uuid: item.uuid,
-          name: item.name,
-          kyaraStyle: item.kyaraStyle,
-          tatie: {
-            ...item.tatie,
-            waitTatieUUID: {
-              val: DEFAULT_KYARA_TATIE_UUID,
-              active: false,
-            },
-          },
-          subtitle: item.subtitle,
-          fileName: item.fileName,
-          fileExtension: item.fileExtension,
-          voiceID: item.voiceID,
-        }
-      })
-      return ans
-    })
-    .then((result: outSettingType[]) => {
-      console.log('追加したデータを書き込む')
       // 追加したデータを書き込む
       const out = outSoftVersion()
       return JSON.stringify(
@@ -731,7 +707,26 @@ export const loadKyaraProfileData = async (confPath: string): Promise<string> =>
           softVar: out.softVer,
           exportStatus: out.exportStatus,
           infoSetting: inputJsonData.infoSetting,
-          settingList: result,
+          tatieOrderList: [],
+          settingList: inputJsonData.settingList.map((item) => {
+            return {
+              dataType: item.dataType,
+              uuid: item.uuid,
+              name: item.name,
+              kyaraStyle: item.kyaraStyle,
+              tatie: {
+                ...item.tatie,
+                waitTatieUUID: {
+                  val: DEFAULT_KYARA_TATIE_UUID,
+                  active: false,
+                },
+              },
+              subtitle: item.subtitle,
+              fileName: item.fileName,
+              fileExtension: item.fileExtension,
+              voiceID: item.voiceID,
+            }
+          }),
         },
         undefined,
         2,
@@ -761,7 +756,7 @@ export const loadVoiceFileData = async (confPath: string): Promise<string> => {
   // 古い設定ファイルだった場合、必要な項目を追加します。
 
   // var 0.2 以下の場合
-  // waitTatieUUID がないので追加する
+  // waitTatieUUID と tatieOrderList がないので追加する
   await new Promise((resolve, reject) => {
     if (inputJsonData.softVer[0] <= 0 && inputJsonData.softVer[1] <= 2) {
       console.log('var 0.2 以下の場合')
@@ -771,37 +766,31 @@ export const loadVoiceFileData = async (confPath: string): Promise<string> => {
     }
   })
     .then(() => {
-      console.log('waitTatieUUID を追加')
-      const ans: outSettingType[] = inputJsonData.settingList.map((item) => {
-        return {
-          dataType: item.dataType,
-          uuid: item.uuid,
-          name: item.name,
-          kyaraStyle: item.kyaraStyle,
-          tatie: {
-            ...item.tatie,
-            waitTatieUUID: {
-              val: DEFAULT_KYARA_TATIE_UUID,
-              active: false,
-            },
-          },
-          subtitle: item.subtitle,
-          fileName: item.fileName,
-          fileExtension: item.fileExtension,
-          voiceID: item.voiceID,
-        }
-      })
-      return ans
-    })
-    .then((result: outSettingType[]) => {
-      console.log('追加したデータを書き込む')
       // 追加したデータを書き込む
       const out = outSoftVersion()
       return JSON.stringify(
         {
           softVar: out.softVer,
           exportStatus: out.exportStatus,
-          settingList: result,
+          settingList: inputJsonData.settingList.map((item) => {
+            return {
+              dataType: item.dataType,
+              uuid: item.uuid,
+              name: item.name,
+              kyaraStyle: item.kyaraStyle,
+              tatie: {
+                ...item.tatie,
+                waitTatieUUID: {
+                  val: DEFAULT_KYARA_TATIE_UUID,
+                  active: false,
+                },
+              },
+              subtitle: item.subtitle,
+              fileName: item.fileName,
+              fileExtension: item.fileExtension,
+              voiceID: item.voiceID,
+            }
+          }),
         },
         undefined,
         2,

--- a/src/utils/analysisMain.ts
+++ b/src/utils/analysisMain.ts
@@ -367,6 +367,7 @@ export const makeUUID = (): string => {
 // fileName が指定されていた場合は、画像ファイル名はそれにする。
 export const enterEncodeImageData = async (
   settingList: outSettingType,
+  tatieSituation: string,
   tempDirPath: string,
   convertPath: string,
   kyaraTatieDirPath: string,
@@ -384,7 +385,7 @@ export const enterEncodeImageData = async (
     convertPath,
     imgData,
     fileName || settingList.fileName,
-    settingList.tatie.tatieUUID.val,
+    settingList.tatie[tatieSituation === 'tatieUUID' ? 'tatieUUID' : 'waitTatieUUID'].val,
     kyaraTatieDirPath,
     outPicDir,
     tempDirPath,
@@ -409,6 +410,7 @@ export const enterEncodeVideoData = async (
   // 画像ファイルの作成を実行
   const imgFilePath = await enterEncodeImageData(
     outSettingData.settingList,
+    'tatieUUID',
     tempDirPath,
     globalSetting.exeFilePath.convert,
     kyaraTatieDirPath,
@@ -445,12 +447,12 @@ export const enterEncodeVideoData = async (
 
 // 画像エンコードのみを実施し、作成した画像ファイルとファイルパスを返す。
 export const enterEncodePicFileData = async (
-  outJsonData: string,
+  outState: { outJsonData: string; tatieSituation: string }[],
   kyaraTatieDirPath: string,
   globalSetting: globalSettingType,
 ): Promise<{ buffer: Uint8Array; path: string }> => {
   // JSONデータを変換
-  const outSettingData: encodeProfileSendReType = JSON.parse(outJsonData)
+  const outSettingData: encodeProfileSendReType = JSON.parse(outState[0].outJsonData)
 
   // 立ち絵の存在チェック
   const noTatieFile = !fs.existsSync(
@@ -467,6 +469,7 @@ export const enterEncodePicFileData = async (
     // 画像ファイルの作成を実行
     const imgFilePath = await enterEncodeImageData(
       outSettingData.settingList,
+      outState[0].tatieSituation,
       tempDirPath,
       globalSetting.exeFilePath.convert,
       kyaraTatieDirPath,

--- a/src/utils/analysisMain.ts
+++ b/src/utils/analysisMain.ts
@@ -396,6 +396,7 @@ export const enterEncodeImageData = async (
 export const enterEncodeVideoData = async (
   voiceFileDirPath: string,
   outJsonData: string,
+  outTatieState: { outJsonData: string; tatieSituation: string }[],
   infoSettingJsonData: string,
   kyaraTatieDirPath: string,
   globalSetting: globalSettingType,
@@ -410,14 +411,7 @@ export const enterEncodeVideoData = async (
   //// 画像ファイルの作成
 
   // 画像ファイルの作成を実行
-  const imgFilePath = await enterEncodeImageData(
-    settingList,
-    'tatieUUID',
-    tempDirPath,
-    globalSetting.exeFilePath.convert,
-    kyaraTatieDirPath,
-    infoSetting.outPicDir,
-  )
+  const imgFilePath = await enterEncodePicFileData(outTatieState, kyaraTatieDirPath, globalSetting)
 
   console.log('main への返送結果: ' + imgFilePath)
 
@@ -426,7 +420,7 @@ export const enterEncodeVideoData = async (
   // FFmpeg用のコマンド作成
   const moviData = await createComMovi(
     settingList,
-    imgFilePath,
+    imgFilePath.path,
     voiceFileDirPath,
     tempDirPath,
     globalSetting.exeFilePath.ffmpeg,

--- a/src/utils/analysisMain.ts
+++ b/src/utils/analysisMain.ts
@@ -235,6 +235,7 @@ export const initializationSetting = (): profileKyaraExportType => {
     softVer: softVersion.softVer,
     exportStatus: softVersion.exportStatus,
     infoSetting: outInfoData(),
+    tatieOrderList: [],
     settingList: outData.value,
   }
 }

--- a/src/utils/analysisMain.ts
+++ b/src/utils/analysisMain.ts
@@ -732,7 +732,7 @@ export const loadKyaraProfileData = async (confPath: string): Promise<string> =>
           softVar: out.softVer,
           exportStatus: out.exportStatus,
           infoSetting: inputJsonData.infoSetting,
-          tatieOrderList: [],
+          tatieOrderList: tatieOrder,
           settingList: inputJsonData.settingList.map((item) => {
             return {
               dataType: item.dataType,

--- a/src/utils/analysisMain.ts
+++ b/src/utils/analysisMain.ts
@@ -16,7 +16,6 @@ import {
   profileKyaraExportType,
   infoSettingType,
   fileListTatieExportType,
-  encodeProfileSendReType,
   globalSettingExportType,
   globalSettingType,
   kyaraProfileListExportType,
@@ -397,11 +396,13 @@ export const enterEncodeImageData = async (
 export const enterEncodeVideoData = async (
   voiceFileDirPath: string,
   outJsonData: string,
+  infoSettingJsonData: string,
   kyaraTatieDirPath: string,
   globalSetting: globalSettingType,
 ): Promise<string> => {
   // JSONデータを変換
-  const outSettingData: encodeProfileSendReType = JSON.parse(outJsonData)
+  const settingList: outSettingType = JSON.parse(outJsonData)
+  const infoSetting: infoSettingType = JSON.parse(infoSettingJsonData)
 
   // 一時ファイルのディレクトリを作成してpathを取得
   const tempDirPath = await createTempDir()
@@ -410,12 +411,12 @@ export const enterEncodeVideoData = async (
 
   // 画像ファイルの作成を実行
   const imgFilePath = await enterEncodeImageData(
-    outSettingData.settingList,
+    settingList,
     'tatieUUID',
     tempDirPath,
     globalSetting.exeFilePath.convert,
     kyaraTatieDirPath,
-    outSettingData.infoSetting.outPicDir,
+    infoSetting.outPicDir,
   )
 
   console.log('main への返送結果: ' + imgFilePath)
@@ -424,7 +425,7 @@ export const enterEncodeVideoData = async (
 
   // FFmpeg用のコマンド作成
   const moviData = await createComMovi(
-    outSettingData.settingList,
+    settingList,
     imgFilePath,
     voiceFileDirPath,
     tempDirPath,
@@ -438,8 +439,8 @@ export const enterEncodeVideoData = async (
   const moviFilePath = createMoviFile(
     globalSetting.exeFilePath.ffmpeg,
     moviData,
-    outSettingData.settingList,
-    outSettingData.infoSetting.outDir,
+    settingList,
+    infoSetting.outDir,
     tempDirPath,
   )
 
@@ -453,12 +454,10 @@ export const enterEncodePicFileData = async (
   globalSetting: globalSettingType,
 ): Promise<{ buffer: Uint8Array; path: string }> => {
   // JSONデータを変換
-  const outSettingData: encodeProfileSendReType = JSON.parse(outState[0].outJsonData)
+  const settingList: outSettingType = JSON.parse(outState[0].outJsonData)
 
   // 立ち絵の存在チェック
-  const noTatieFile = !fs.existsSync(
-    path.join(kyaraTatieDirPath, outSettingData.settingList.tatie.tatieUUID.val + '.png'),
-  )
+  const noTatieFile = !fs.existsSync(path.join(kyaraTatieDirPath, settingList.tatie.tatieUUID.val + '.png'))
 
   // 立ち絵が存在する場合はファイル変換を実行する。
   if (!noTatieFile) {
@@ -469,7 +468,7 @@ export const enterEncodePicFileData = async (
 
     // 画像ファイルの作成を実行
     const imgFilePath = await enterEncodeImageData(
-      outSettingData.settingList,
+      settingList,
       outState[0].tatieSituation,
       tempDirPath,
       globalSetting.exeFilePath.convert,

--- a/src/utils/analysisMain.ts
+++ b/src/utils/analysisMain.ts
@@ -489,28 +489,6 @@ export const enterEncodePicFileData = async (
     }
   }
 
-  // const imgList = await Promise.all(
-  //   outState.map(async (e, i) => {
-  //     // console.log('e.outJsonData: ' + e.outJsonData)
-  //     const setting: outSettingType = JSON.parse(e.outJsonData)
-  //     console.log('変換: ' + setting.name + ', ' + i)
-  //     if (fs.existsSync(path.join(kyaraTatieDirPath, setting.tatie.tatieUUID.val + '.png'))) {
-  //       //// 画像ファイルの作成
-
-  //       // 画像ファイルの作成を実行
-  //       return await enterEncodeImageData(
-  //         setting,
-  //         e.tatieSituation,
-  //         tempDirPath,
-  //         globalSetting.exeFilePath.convert,
-  //         kyaraTatieDirPath,
-  //         tempDirPath,
-  //         'tb_' + i,
-  //       )
-  //     }
-  //   }),
-  // )
-
   console.log('imgList: ' + imgList[0] + ' ' + imgList[1] + ' ' + imgList[2])
   console.log('imgList:ここまで ')
 

--- a/src/utils/comExec/comEnter.ts
+++ b/src/utils/comExec/comEnter.ts
@@ -240,6 +240,9 @@ export const imgCompositeFile = async (
   outDir: string,
   outFileName: string,
 ): Promise<string> => {
+  // 配列を逆順にする
+  imgList.reverse()
+
   console.log('でーた: ' + imgList[0] + ', ' + imgList[1] + ', ' + imgList[2])
   // imgListの一番目だけ取り出す。
   const compImage = imgList.splice(0, 1)

--- a/src/utils/comExec/comEnter.ts
+++ b/src/utils/comExec/comEnter.ts
@@ -231,3 +231,29 @@ export const enterEncodeSmallTatie = async (
 
   return tempTatiePic.stdout
 }
+
+// 作成済みの立ち絵画像を配列に入っている順番で合成して、その絶対パス（拡張子入り）を返す。
+// imgListのファイルパスは絶対パス（拡張子入り）にする。
+export const imgCompositeFile = async (
+  convertPath: string,
+  imgList: string[],
+  outDir: string,
+  outFileName: string,
+): Promise<string> => {
+  console.log('でーた: ' + imgList[0] + ', ' + imgList[1] + ', ' + imgList[2])
+  // imgListの一番目だけ取り出す。
+  const compImage = imgList.splice(0, 1)
+
+  console.log('でーたcompImage: ' + compImage[0])
+  // 順番よく合成する。合成したらcompImageの名前を変える
+  imgList.map((e) => {
+    console.log('でーたconcat: ' + e)
+    compImage.push(e, '-composite')
+  })
+
+  console.log('実行: ' + compImage[0] + ', ' + compImage[1] + ', ' + compImage[2] + ', ' + compImage[3])
+
+  await execFile(convertPath, compImage.concat([path.join(outDir, outFileName + '.png')]))
+
+  return path.join(outDir, outFileName + '.png')
+}


### PR DESCRIPTION
## Pull Request 概要

複数人を登場させる場合、セリフのないキャラの立ち絵は、別途他のレイヤーに入れる必要があります。

このため、それらの立ち絵も作成される WebM ファイルに入れて、手間を削減します。

## 変更点

- キャラ設定に対して喋っていないときの立ち絵を設定できるようにします。
- 新たに、プロファイルごとに`立ち絵順序の設定`の項目を追加して、表示する立ち絵を設定できるようにします。
- 動画ファイルに対しては、個別にプロファイルとは違う`立ち絵順序の設定`を行えるようにします。
- 今までWebMファイルと同時に、画面サイズに加工した立ち絵のPNGファイルも出力していましたが、不要になったと判断し、廃止しました。

## その他


