### PR TITLE
キャラ設定の順番をマウスで並べ替えできるように変更 #1410

### DIFF
--- a/src/components/makeComList.vue
+++ b/src/components/makeComList.vue
@@ -284,7 +284,7 @@ const loadVoiceDirList = (): void => {
     // 別ディレクトリの音声ファイル情報がある場合はそれを排除します。
     dateList.value = tempbuf.filter((item) => item.dataType !== 'seid')
 
-    // 音声ファイル名と同じ名前の字幕テキストファイルを読み込んで、字幕の内容をUUIDをキーにした連想配列に入れる。
+    // 音声ファイルと同名の字幕テキストファイルを読み込んで、字幕の内容をUUIDをキーにした連想配列に入れる。
     const itemList: { uuid: string; fileName: string }[] = ans.map((item) => {
       return { uuid: item.uuid, fileName: item.fileName }
     })

--- a/src/components/makeComList.vue
+++ b/src/components/makeComList.vue
@@ -172,6 +172,7 @@ const addNewKyara = (dataType: dataTextType, kyaraName: string, kyaraStyle: stri
           undefined,
           undefined,
           undefined,
+          undefined,
           yomAPI.getPlatformData(),
         ),
       )

--- a/src/components/makeComList.vue
+++ b/src/components/makeComList.vue
@@ -427,6 +427,24 @@ const searchKyaraEvent = (text: string) => {
   console.log('searchKyaraString: ' + searchKyaraString.value)
 }
 
+// キャラ設定の表示順をマウスで入れ替えるため、
+// 移動開始時の数値を保存する
+const KyaraListOrderDragStart = (index: number) => {
+  dragStartIndex.value = index
+}
+
+// キャラ設定の順番を入れ替える
+const KyaraListOrderDragMove = (index: number) => {
+  // もし、移動されていた場合は移動対象の配列要素を取り出して、
+  // indexで指定された場所に差し込む形で追加する。
+  // 処理が終わったら dragStartIndex.value と index の値を一致させて処理が無駄に実行されないようにする。
+  if (index !== dragStartIndex.value) {
+    const moveItem = dateList.value.splice(dragStartIndex.value, 1)[0]
+    dateList.value.splice(index, 0, moveItem)
+    dragStartIndex.value = index
+  }
+}
+
 // seidキャラ設定のfileTatieOrderListを子コンポーネントに渡すか判断する
 // true ならfileTatieOrderList、falesならプロファイルのtatieOrderListとなる
 const selectFileTatieOrderSetting = (): void => {
@@ -747,6 +765,8 @@ watch(
         :checkIntoTatieOrderList="(uuid: string) => checkIntoTatieOrderList(uuid)"
         :searchKyaraEvent="searchKyaraEvent"
         :CopyKyaraSetting="CopyKyaraSetting"
+        :KyaraListOrderDragStart="(index: number) => KyaraListOrderDragStart(index)"
+        :KyaraListOrderDragMove="(index: number) => KyaraListOrderDragMove(index)"
         ref="setKyaraListRef"
       />
       <!-- キャラ設定プロファイルの追加ボタンは、defoでのみ表示 -->

--- a/src/components/setKyaraList.vue
+++ b/src/components/setKyaraList.vue
@@ -27,6 +27,7 @@ import MaterialIcons from '@/components/accessories/icons/MaterialIcons.vue'
 import SelectProfileList from '@/components/unit/SelectProfileList.vue'
 import SearchInputUnit from '@/components/unit/SearchInputUnit.vue'
 import SelectDisplayKyaraRightClickMenu from '@/components/accessories/SelectDisplayKyaraRightClickMenu.vue'
+import SelectSeidList from '@/components/unit/SelectSeidList.vue'
 
 const { yomAPI } = window
 
@@ -242,7 +243,7 @@ watch(
         ref="refSearchString"
       />
       <div
-        v-if="settype !== 'defo'"
+        v-if="settype !== 'defo' && settype !== 'seid'"
         v-for="(item, index) in dateList"
         v-bind:key="item.uuid"
         :ref="selectKyaraRef"
@@ -257,9 +258,7 @@ watch(
           v-if="
             settype === item.dataType &&
             isEditOpen !== item.uuid &&
-            (settype !== 'seid'
-              ? FindAllString(refSearchString.searchString, [item.name, settype === 'kyast' && item.kyaraStyle])
-              : true)
+            FindAllString(refSearchString.searchString, [item.name, settype === 'kyast' && item.kyaraStyle])
           "
         >
           <!-- 個々の設定タイプに応じて表示 -->
@@ -268,19 +267,7 @@ watch(
             <div class="max-w-2/3 min-w-24 truncate" :title="item.name">{{ item.name }}</div>
             <div class="truncate" :title="item.kyaraStyle">（{{ item.kyaraStyle }}）</div>
           </div>
-          <!-- 設定が有効で、字幕テキストファイルがある場合はその内容を表示 -->
-          <div
-            v-else-if="item.dataType === 'seid'"
-            class="w-full truncate"
-            :title="
-              useSubText && subTextStringList[item.uuid].active
-                ? subTextStringList[item.uuid].val
-                : item.fileName + '.' + item.fileExtension
-            "
-          >
-            {{ useSubText && subTextStringList[item.uuid].active ? subTextStringList[item.uuid].val : item.fileName }}
-          </div>
-          <div class="flex h-full" v-if="selectKyara === index && settype !== 'seid'">
+          <div class="flex h-full" v-if="selectKyara === index">
             <MaterialIcons
               icon="MoreHoriz"
               @click.right="() => (isMenuOpen = true)"
@@ -297,15 +284,6 @@ watch(
               />
             </div>
           </div>
-          <button
-            class="h-full rounded-md border border-gray-700 bg-yellow-300"
-            v-else-if="selectKyara === index && settype === 'seid'"
-            title="エンコードを実行"
-            @click.stop="encodeCliek(index)"
-            :disabled="disableEnterEncode"
-          >
-            <MaterialIcons icon="CinematicBlur" />
-          </button>
         </div>
         <AccEditKyaraName
           :isNewOpen="isEditOpen === item.uuid"
@@ -331,6 +309,20 @@ watch(
           :createProfileData="createProfileData"
           :selectAreaRef="selectAreaRef"
           ref="selectProfileListRef"
+        />
+      </div>
+      <div v-if="settype === 'seid'" class="h-full w-full">
+        <SelectSeidList
+          :dateList="dateList"
+          :settype="settype"
+          :selectKyara="selectKyara"
+          :KyaraListOrderDragStart="(index: number) => KyaraListOrderDragStart(index)"
+          :KyaraListOrderDragMove="(index: number) => KyaraListOrderDragMove(index)"
+          :setDataTypeClick="(index: number, item: outSettingType) => setDataTypeClick(index, item)"
+          :subTextStringList="subTextStringList"
+          :useSubText="useSubText"
+          :encodeCliek="(index: number) => encodeCliek(index)"
+          :disableEnterEncode="disableEnterEncode"
         />
       </div>
     </div>

--- a/src/components/setKyaraList.vue
+++ b/src/components/setKyaraList.vue
@@ -16,6 +16,8 @@ const props = defineProps<{
   checkIntoTatieOrderList: (uuid: string) => boolean
   searchKyaraEvent: (text: string) => void
   CopyKyaraSetting: (dataType: dataTextType, uuid: string) => void
+  KyaraListOrderDragStart: (index: number) => void
+  KyaraListOrderDragMove: (index: number) => void
 }>()
 import { watch, ref, nextTick } from 'vue'
 import { outSettingType, dataTextType, editKyaraNameType } from '@/type/data-type'
@@ -239,7 +241,16 @@ watch(
         @searchKyaraEvent="searchKyaraEvent"
         ref="refSearchString"
       />
-      <div v-if="settype !== 'defo'" v-for="(item, index) in dateList" v-bind:key="item.uuid" :ref="selectKyaraRef">
+      <div
+        v-if="settype !== 'defo'"
+        v-for="(item, index) in dateList"
+        v-bind:key="item.uuid"
+        :ref="selectKyaraRef"
+        :draggable="true"
+        @dragstart="() => KyaraListOrderDragStart(index)"
+        @dragenter="() => KyaraListOrderDragMove(index)"
+        @dragover.prevent
+      >
         <div
           :class="actSet(item.uuid)"
           @click="setDataTypeClick(index, item)"

--- a/src/components/unit/SelectSeidList.vue
+++ b/src/components/unit/SelectSeidList.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+// 音声ファイル個別の設定のリストを表示し、
+// 選択することで切り替えられるようにする。
+
+const props = defineProps<{
+  dateList: outSettingType[]
+  settype: dataTextType
+  selectKyara: number
+  KyaraListOrderDragStart: (index: number) => void
+  KyaraListOrderDragMove: (index: number) => void
+  setDataTypeClick: (index: number, item: outSettingType) => void
+  useSubText: boolean
+  subTextStringList: { [key: string]: { val: string; active: boolean } }
+  encodeCliek: (index: number) => void
+  disableEnterEncode: boolean
+}>()
+
+import { outSettingType, dataTextType } from '@/type/data-type'
+import MaterialIcons from '@/components/accessories/icons/MaterialIcons.vue'
+import { MakeClassString } from '@/utils/analysisGeneral'
+</script>
+
+<template>
+  <div>
+    <div
+      v-for="(item, index) in dateList"
+      v-bind:key="item.uuid"
+      :draggable="true"
+      @dragstart="() => KyaraListOrderDragStart(index)"
+      @dragenter="() => KyaraListOrderDragMove(index)"
+      @dragover.prevent
+    >
+      <div
+        :class="
+          MakeClassString(
+            'mx-1 mt-1 flex h-8 items-center justify-between border border-gray-600 p-1 hover:bg-blue-500 hover:text-gray-200',
+            props.dateList[props.selectKyara]?.uuid === item.uuid ? 'bg-blue-400' : 'bg-blue-200',
+          )
+        "
+        @click="() => setDataTypeClick(index, item)"
+        v-if="item.dataType === 'seid' && item.fileActive"
+      >
+        <!-- 個々の設定タイプに応じて表示 -->
+        <div class="w-3/6 truncate" :title="item.name">{{ item.name }}</div>
+        <!-- 設定が有効で、字幕テキストファイルがある場合はその内容を表示 -->
+        <div
+          class="w-full truncate"
+          :title="
+            useSubText && subTextStringList[item.uuid].active
+              ? subTextStringList[item.uuid].val
+              : item.fileName + '.' + item.fileExtension
+          "
+        >
+          {{ useSubText && subTextStringList[item.uuid].active ? subTextStringList[item.uuid].val : item.fileName }}
+        </div>
+        <button
+          class="h-full w-11 rounded-md border border-gray-700 bg-yellow-300"
+          v-if="selectKyara === index"
+          title="エンコードを実行"
+          @click.stop="() => encodeCliek(index)"
+          :disabled="disableEnterEncode"
+        >
+          <MaterialIcons icon="CinematicBlur" classString="mx-1 mh-1" />
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/type/data-type.ts
+++ b/src/type/data-type.ts
@@ -147,6 +147,10 @@ export type outSettingType = {
   fileExtension: string // ファイル拡張子     (seidの音声ファイル用)
   voiceID: string // ID                       (seidの音声ファイル用)
   fileTatieOrderList: statusTatieOrderList // 複数立ち絵の表示順番を記録          (seidの音声ファイル用)
+  // 個別設定ファイルを読み込んだときに、
+  // 該当する音声ファイルが存在するかチェックして、
+  // あるならtrueにしてリストに表示するように指示    (seidの音声ファイル用)
+  fileActive: boolean
 }
 
 // 各情報タイプで選択していたキャラのID情報を記録

--- a/src/utils/analysisData.ts
+++ b/src/utils/analysisData.ts
@@ -191,6 +191,7 @@ export const createNewDateList = (
   fileExtension?: string,
   voiceID?: string,
   fileTatieOrderList?: tatieOrderListType[],
+  fileActive?: boolean,
   platform?: NodeJS.Platform,
 ): outSettingType => {
   return {
@@ -260,6 +261,7 @@ export const createNewDateList = (
     fileExtension: fileExtension !== undefined ? fileExtension : '',
     voiceID: voiceID !== undefined ? voiceID : '',
     fileTatieOrderList: { val: fileTatieOrderList ?? [], active: fileTatieOrderList !== undefined ? true : false },
+    fileActive: fileActive !== undefined ? fileActive : false,
   }
 }
 
@@ -276,6 +278,7 @@ export const CreateCopyDateList = (kyraData: outSettingType, dataType: dataTextT
     fileExtension: '',
     voiceID: '',
     fileTatieOrderList: { val: [], active: false },
+    fileActive: false,
   }
 }
 

--- a/src/utils/analysisFile.ts
+++ b/src/utils/analysisFile.ts
@@ -10,7 +10,7 @@ import {
   tatieSituationType,
 } from '../type/data-type'
 import { ref } from 'vue'
-import { createNewDataID, createNewDateList, createVoiceFileEncodeSetting } from './analysisData'
+import { createNewDateList, createVoiceFileEncodeSetting } from './analysisData'
 import { createDefoFileListTatie, NowTimeData } from './analysisGeneral'
 import { DEFAULT_KYARA_TATIE_UUID } from '../data/data'
 const { yomAPI } = window
@@ -39,6 +39,30 @@ export const analysisFileName = (
     }
   }
 
+  //// 個別設定リストの順番に、音声ファイルが存在するか確認する。
+  //// 存在する場合はfileActiveをtrueにし、ない場合はfalesにする。
+
+  // 取得結果が空でなければ実行
+  if (inputData.value?.settingList !== undefined && inputData.value?.settingList?.length !== 0) {
+    ansList.value = inputData.value.settingList.map((e) => {
+      // リストのファイルが存在するか確認し、
+      // 存在する場合はそのfileActiveをtrueにする。
+      const fileAns = lists.findIndex((f) => f === e.fileName + '.' + e.fileExtension)
+      if (fileAns !== -1) {
+        e.fileActive = true
+        // 存在したファイルはリストから消す
+        lists.splice(fileAns, 1)
+        return e
+      } else {
+        // ファイルが存在しないものをfalesにする
+        e.fileActive = false
+        return e
+      }
+    })
+  }
+
+  //// 個別設定リストにない音声ファイルを読み込んでリストに加える。
+
   // 取得結果が空でなければ実行
   if (lists.length !== 0) {
     // ファイルリストを調査し、必要な情報を入力する。
@@ -65,37 +89,23 @@ export const analysisFileName = (
         const tempStyle = nameData[1].slice(kyaraName.length)
         const kyaraStyle = tempStyle !== undefined ? tempStyle.slice(1, -1) : undefined
 
-        // ファイル名等が同じ個別設定データがある場合はそれを取り出す
-        const fileSetting = inputData.value?.settingList.find(
-          (e) =>
-            e.fileName === fileName &&
-            e.fileExtension === fileExtension &&
-            e.name === kyaraName &&
-            e.kyaraStyle === kyaraStyle,
+        // 新規に出力する。
+        ansList.value.push(
+          createNewDateList(
+            'seid',
+            yomAPI.getUUID(),
+            kyaraName,
+            kyaraStyle,
+            {},
+            {},
+            fileName,
+            fileExtension,
+            voiceID,
+            [],
+            true,
+            yomAPI.getPlatformData(),
+          ),
         )
-
-        // 同じ設定があるのであれば、それを出力する。
-        // なければ新規に出力する。
-        if (fileSetting !== undefined) {
-          ansList.value.push(fileSetting)
-        } else {
-          ansList.value.push(
-            createNewDateList(
-              'seid',
-              yomAPI.getUUID(),
-              kyaraName,
-              kyaraStyle,
-              {},
-              {},
-              fileName,
-              fileExtension,
-              voiceID,
-              [],
-              true,
-              yomAPI.getPlatformData(),
-            ),
-          )
-        }
       }
     }
   }

--- a/src/utils/analysisFile.ts
+++ b/src/utils/analysisFile.ts
@@ -91,6 +91,7 @@ export const analysisFileName = (
               fileExtension,
               voiceID,
               [],
+              true,
               yomAPI.getPlatformData(),
             ),
           )

--- a/src/utils/analysisMain.ts
+++ b/src/utils/analysisMain.ts
@@ -215,6 +215,7 @@ export const initializationSetting = (): profileKyaraExportType => {
         '',
         '',
         [],
+        false,
         process.platform,
       ),
     )
@@ -223,7 +224,20 @@ export const initializationSetting = (): profileKyaraExportType => {
     if (e.kyaraStyle !== undefined) {
       e.kyaraStyle.map((ekyaraStyle) =>
         outData.value.push(
-          createNewDateList('kyast', makeUUID(), e.kyaraName, ekyaraStyle, {}, {}, '', '', '', [], process.platform),
+          createNewDateList(
+            'kyast',
+            makeUUID(),
+            e.kyaraName,
+            ekyaraStyle,
+            {},
+            {},
+            '',
+            '',
+            '',
+            [],
+            false,
+            process.platform,
+          ),
         ),
       )
     }
@@ -751,6 +765,7 @@ export const loadKyaraProfileData = async (confPath: string): Promise<string> =>
               fileExtension: item.fileExtension,
               voiceID: item.voiceID,
               fileTatieOrderList: { val: tatieOrder, active: false },
+              fileActive: false,
             }
           }),
         },
@@ -817,6 +832,7 @@ export const loadVoiceFileData = async (confPath: string): Promise<string> => {
               fileExtension: item.fileExtension,
               voiceID: item.voiceID,
               fileTatieOrderList: { val: tatieOrder, active: false },
+              fileActive: false,
             }
           }),
         },


### PR DESCRIPTION
## Pull Request 概要

キャラ設定の順番を変えられるように、変更します。

## 変更点

- キャラ設定の順番を入れ替えられるように変更します。
- 音声ファイル個別の設定の順番を入れ替えられるように変更します。

## その他

- 立ち絵画像ファイル一覧の順番入れ替えについては、自動ソートと検索機能があるため、今のところ必要ないと判断し、今回は実装を延期します。

