### PR TITLE
デフォルトキャラ設定の待機中の立ち絵を設定できなくなっていたので修正 #1511

### DIFF
--- a/src/utils/analysisMain.ts
+++ b/src/utils/analysisMain.ts
@@ -757,7 +757,7 @@ export const loadKyaraProfileData = async (confPath: string): Promise<string> =>
                 ...item.tatie,
                 waitTatieUUID: {
                   val: DEFAULT_KYARA_TATIE_UUID,
-                  active: false,
+                  active: item.dataType === 'defo' ? true : false,
                 },
               },
               subtitle: item.subtitle,
@@ -824,7 +824,7 @@ export const loadVoiceFileData = async (confPath: string): Promise<string> => {
                 ...item.tatie,
                 waitTatieUUID: {
                   val: DEFAULT_KYARA_TATIE_UUID,
-                  active: false,
+                  active: item.dataType === 'defo' ? true : false,
                 },
               },
               subtitle: item.subtitle,


### PR DESCRIPTION
## Pull Request 概要

旧バージョン(0.2.2以下)で作成されたプロファイルの場合、
デフォルトキャラ設定の待機中の立ち絵を設定できなくなっていたので修正します。

## 変更点


## その他


