### PR TITLE
createVoiceFileEncodeSetting()でfileTatieOrderListとfileActiveの値を #1517

### DIFF
--- a/src/utils/analysisData.ts
+++ b/src/utils/analysisData.ts
@@ -406,6 +406,8 @@ export const createVoiceFileEncodeSetting = (index: number, dateList: outSetting
     dateList[index].fileName,
     dateList[index].fileExtension,
     dateList[index].voiceID,
+    dateList[index].fileTatieOrderList.active ? dateList[index].fileTatieOrderList.val : undefined,
+    dateList[index].fileActive,
   )
 }
 


### PR DESCRIPTION
## Pull Request 概要

createVoiceFileEncodeSetting()でfileTatieOrderListとfileActiveの値を返していなかった問題を修正します。

## 変更点


## その他


