### PR TITLE
変換した立ち絵画像ファイルの保存先を指定する項目を非表示に変更 #1522

### DIFF
--- a/src/components/setMainInfo.vue
+++ b/src/components/setMainInfo.vue
@@ -31,21 +31,6 @@ const changeDir = async (path: string, title: string, changeInfo: 'outDir' | 'ou
         </button>
       </div>
     </div>
-    <!-- 画面サイズの画像保存先 -->
-    <div class="flex border-b-[1px] border-gray-400 py-2">
-      <div class="mr-2 flex w-full justify-between">
-        <div title="出力動画の画面サイズと同じ大きさに拡大した立ち絵画像ファイル" class="flex items-center">
-          画像保存先
-        </div>
-        <button
-          class="w-96 truncate rounded-md border border-gray-600 bg-sky-300 px-2 py-1 hover:bg-sky-500"
-          :title="infoData.outPicDir"
-          @click="changeDir(infoData.outPicDir, '画像保存先', 'outPicDir')"
-        >
-          {{ infoData.outPicDir }}
-        </button>
-      </div>
-    </div>
     <!-- 「-」を区切り文字として使うかどうか -->
     <div class="flex border-b-[1px] border-gray-400 py-2">
       <div class="mr-2 flex w-full justify-between">

--- a/src/type/data-type.ts
+++ b/src/type/data-type.ts
@@ -39,7 +39,7 @@ export type subtitleSetting = {
 // 基本設定
 export type infoSettingType = {
   outDir: string // 動画出力先
-  outPicDir: string // 画面サイズの画像保存先
+  outPicDir: string // 画面サイズの画像保存先 0.3以降は未使用
   cutHR: boolean // 「-」を区切り文字として使うかどうか
 }
 

--- a/src/utils/analysisMain.ts
+++ b/src/utils/analysisMain.ts
@@ -133,10 +133,10 @@ export const outInfoData = (): infoSettingType => {
     }
     if (!fs.existsSync(outMovieDir)) throw new Error('動画ディレクトリ作成失敗')
 
-    if (!fs.existsSync(outPicDir)) {
-      fs.mkdirSync(outPicDir)
-    }
-    if (!fs.existsSync(outPicDir)) throw new Error('画像ディレクトリ作成失敗')
+    // if (!fs.existsSync(outPicDir)) {
+    //   fs.mkdirSync(outPicDir)
+    // }
+    // if (!fs.existsSync(outPicDir)) throw new Error('画像ディレクトリ作成失敗')
 
     // 作成した情報を返す
 


### PR DESCRIPTION
## Pull Request 概要

基本設定から、変換した立ち絵画像ファイルの保存先を指定する項目を削除します。

## 変更点


## その他

別件で使用する可能性があるため、configには設定を残します。
