### PR TITLE
立ち絵の色を加工できる機能を追加 #1547

### DIFF
--- a/src/components/accessories/EditDisplayTatieKyaraColorEdit.vue
+++ b/src/components/accessories/EditDisplayTatieKyaraColorEdit.vue
@@ -1,0 +1,101 @@
+<script setup lang="ts">
+const props = defineProps<{
+  selectKyara: number
+  settype: dataTextType
+  dateList: outSettingType[]
+  tatieSetting: tatieSettingType
+  higherUpList: [number, number]
+  editName: string
+  titleName: string
+}>()
+// 立ち絵の色をどのように加工するか設定。
+
+import type { dataTextType, outSettingType, tatieSettingType, tatieColorSelectStyleType } from 'src/type/data-type'
+import { SelectTatieIndexHigherUpData } from '@/utils/analysisData'
+import { ref, watch } from 'vue'
+import SelectDisplayHigherUpStatus from '@/components/accessories/SelectDisplayHigherUpStatus.vue'
+import SelectDisplayTatieKyaraColorType from '@/components/accessories/SelectDisplayTatieKyaraColorType.vue'
+
+const ChangeTatieColor = (select: tatieColorSelectStyleType): void => {
+  props.dateList[props.selectKyara].tatie.colorEdit.val.selectStyle = select
+}
+
+const isOpen = ref<boolean>(false)
+
+// 設定のリスト
+const selectList = { default: 'なし', colorspace: 'グレースケール', negate: 'カラー反転', sepiaTone: 'セピア調' }
+
+// どの上位設定を使うか決定する
+const higherUpEditKyara = ref<number>(
+  SelectTatieIndexHigherUpData(props.higherUpList, props.dateList, props.tatieSetting),
+)
+
+watch(
+  () => props.higherUpList,
+  () => {
+    higherUpEditKyara.value = SelectTatieIndexHigherUpData(props.higherUpList, props.dateList, props.tatieSetting)
+  },
+)
+</script>
+
+<template>
+  <div class="flex border-b-[1px] border-gray-400 py-2">
+    <div class="mr-2 flex w-full justify-between">
+      <div :title="titleName">{{ editName }}</div>
+      <!-- 
+          ここの設定を使用する場合に入力できる。
+          上位設定を使用する場合は表示のみ。
+         -->
+
+      <div class="flex w-2/3 flex-col">
+        <div v-if="dateList[selectKyara].tatie.colorEdit.active" class="flex w-full">
+          <button
+            class="w-1/2 border border-gray-800 bg-blue-300 px-1 hover:bg-blue-600 hover:text-gray-200"
+            @click="() => (isOpen = true)"
+          >
+            {{ selectList[dateList[selectKyara].tatie.colorEdit.val.selectStyle] }}
+          </button>
+          <div v-if="dateList[selectKyara].tatie.colorEdit.val.selectStyle === 'sepiaTone'" class="flex">
+            <input
+              class="ml-1 w-1/2"
+              type="range"
+              min="0"
+              max="100"
+              v-model="dateList[selectKyara].tatie.colorEdit.val.sepiaToneOption"
+            />
+            <input
+              class="ml-5 w-1/4"
+              type="number"
+              min="0"
+              max="100"
+              v-model="dateList[selectKyara].tatie.colorEdit.val.sepiaToneOption"
+            />
+          </div>
+        </div>
+        <button v-else class="w-1/2 border border-gray-800 bg-blue-300 px-1 text-gray-600" disabled>
+          {{ selectList[dateList[higherUpEditKyara].tatie.colorEdit.val.selectStyle] }}
+        </button>
+        <div v-if="isOpen && dateList[selectKyara].tatie.colorEdit.active" class="relative">
+          <SelectDisplayTatieKyaraColorType
+            :selectTatieColor="dateList[selectKyara].tatie.colorEdit.val.selectStyle"
+            :ClickClose="() => (isOpen = false)"
+            :ChangeTatieColor="(select: tatieColorSelectStyleType) => ChangeTatieColor(select)"
+            :selectList="selectList"
+          />
+        </div>
+
+        <div v-if="dateList[selectKyara].tatie.colorEdit.active" class="w-full"></div>
+      </div>
+    </div>
+    <SelectDisplayHigherUpStatus
+      :settype="props.settype"
+      :actStatus="dateList[selectKyara].tatie[tatieSetting].active"
+      :higherUpType="dateList[higherUpEditKyara].dataType"
+      :onClick="
+        () =>
+          (props.dateList[props.selectKyara].tatie[props.tatieSetting].active =
+            !props.dateList[props.selectKyara].tatie[props.tatieSetting].active)
+      "
+    />
+  </div>
+</template>

--- a/src/components/accessories/SelectDisplayTatieKyaraColorType.vue
+++ b/src/components/accessories/SelectDisplayTatieKyaraColorType.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+const props = defineProps<{
+  selectTatieColor: string
+  ClickClose: () => void
+  ChangeTatieColor: (select: tatieColorSelectStyleType) => void
+  selectList: { [key in tatieColorSelectStyleType]: string }
+}>()
+
+import type { tatieColorSelectStyleType } from 'src/type/data-type'
+import { MakeClassString } from '@/utils/analysisGeneral'
+</script>
+
+<template>
+  <div class="fixed top-0 right-0 flex h-screen w-screen items-center justify-center" @click.self="() => ClickClose()">
+    <!-- 画面外クリックでクローズ -->
+  </div>
+  <div class="absolute" @click="() => ClickClose()">
+    <div
+      v-for="(item, key) in selectList"
+      v-bind:key="key"
+      :class="
+        MakeClassString(
+          'border-2 border-gray-600 px-3 py-2 hover:bg-blue-600 hover:text-gray-200',
+          selectTatieColor === key ? 'bg-blue-300' : 'bg-blue-100',
+        )
+      "
+      @click="() => ChangeTatieColor(key)"
+    >
+      {{ item }}
+    </div>
+  </div>
+</template>

--- a/src/components/setTatie.vue
+++ b/src/components/setTatie.vue
@@ -13,6 +13,7 @@ import EditDisplayTatiePicPathKyaraData from '@/components/accessories/EditDispl
 import EditDisplayTatieCheckboxKyaraData from '@/components/accessories/EditDisplayTatieCheckboxKyaraData.vue'
 import EditDisplayTatieSideKyaraData from '@/components/accessories/EditDisplayTatieSideKyaraData.vue'
 import EditDisplayTatieKyaraRotate from '@/components/accessories/EditDisplayTatieKyaraRotate.vue'
+import EditDisplayTatieKyaraColorEdit from '@/components/accessories/EditDisplayTatieKyaraColorEdit.vue'
 </script>
 
 <template>
@@ -46,6 +47,15 @@ import EditDisplayTatieKyaraRotate from '@/components/accessories/EditDisplayTat
       editName="画面の縦(px)"
       inputMin="0"
       titleName="作成する動画の縦の長さを指定します"
+    />
+    <EditDisplayTatieKyaraColorEdit
+      :settype="settype"
+      :dateList="dateList"
+      :selectKyara="selectKyara"
+      :higherUpList="higherUpList"
+      tatieSetting="colorEdit"
+      editName="カラー設定"
+      titleName="立ち絵の色を加工します"
     />
     <EditDisplayTatieCheckboxKyaraData
       :settype="settype"

--- a/src/type/data-type.ts
+++ b/src/type/data-type.ts
@@ -138,13 +138,16 @@ export type tatieSideType =
 // 'sepiaTone': セピア調
 // 'default': 加工なし（デフォルト）
 export type tatieColorOption = {
-  selectStyle: 'colorspace' | 'negate' | 'monochrome' | 'sepiaTone' | 'default'
+  selectStyle: tatieColorSelectStyleType
   // 各項目のオプション設定
   colorspaceOption: string
   negateOption: string
   monochromeOption: string
   sepiaToneOption: number
 }
+
+// 立ち絵の色の加工スタイル
+export type tatieColorSelectStyleType = 'colorspace' | 'negate' | 'sepiaTone' | 'default'
 
 // 字幕の文字列をどちらに寄せるか（左 右 中央）
 export type subAlignmentSideType = 'Left' | 'Right' | 'Center' | null

--- a/src/type/data-type.ts
+++ b/src/type/data-type.ts
@@ -10,6 +10,7 @@ export type tatieSetting = {
   tatiePwPs: statusNumber // 立ち絵を横に移動
   tatiePhPs: statusNumber // 立ち絵を縦に移動
   rotate: statusNumber // 立ち絵の傾き
+  colorEdit: statusColorEdit // 立ち絵の色を加工
   fps: statusNumber // フレームレート
 }
 
@@ -61,6 +62,10 @@ export type statustatieSide = {
   val: tatieSideType
   active: boolean
 }
+export type statusColorEdit = {
+  val: tatieColorOption
+  active: boolean
+}
 export type statusSubAlignment = {
   val: subAlignmentSideType
   active: boolean
@@ -83,6 +88,7 @@ export type tatieSettingType =
   | 'tatiePwPs'
   | 'tatiePhPs'
   | 'rotate'
+  | 'colorEdit'
   | 'fps'
 
 // 字幕の項目のタイプ
@@ -124,6 +130,21 @@ export type tatieSideType =
   | 'SouthWest'
   | 'South'
   | 'SouthEast'
+
+// 立ち絵画像の色を加工する設定
+// 'colorspace': グレースケール
+// 'negate': カラーの反転
+// 'monochrome': モノクロ2階調
+// 'sepiaTone': セピア調
+// 'default': 加工なし（デフォルト）
+export type tatieColorOption = {
+  selectStyle: 'colorspace' | 'negate' | 'monochrome' | 'sepiaTone' | 'default'
+  // 各項目のオプション設定
+  colorspaceOption: string
+  negateOption: string
+  monochromeOption: string
+  sepiaToneOption: number
+}
 
 // 字幕の文字列をどちらに寄せるか（左 右 中央）
 export type subAlignmentSideType = 'Left' | 'Right' | 'Center' | null

--- a/src/utils/analysisData.ts
+++ b/src/utils/analysisData.ts
@@ -181,6 +181,16 @@ export const createVoiceFileEncodeSetting = (index: number, dateList: outSetting
     tatiePwPs: { val: 0, active: false },
     tatiePhPs: { val: 0, active: false },
     rotate: { val: 0, active: false },
+    colorEdit: {
+      val: {
+        selectStyle: 'default',
+        colorspaceOption: 'gray',
+        negateOption: '',
+        monochromeOption: '',
+        sepiaToneOption: 80,
+      },
+      active: false,
+    },
     fps: { val: 0, active: false },
   })
   const outDataSubtitle = ref<subtitleSetting>({
@@ -256,6 +266,7 @@ export const createVoiceFileEncodeSetting = (index: number, dateList: outSetting
       tatiePwPs: outDataTatie.value.tatiePwPs.val,
       tatiePhPs: outDataTatie.value.tatiePhPs.val,
       rotate: outDataTatie.value.rotate.val,
+      colorEdit: outDataTatie.value.colorEdit.val,
       fps: outDataTatie.value.fps.val,
     },
     {

--- a/src/utils/analysisGeneral.ts
+++ b/src/utils/analysisGeneral.ts
@@ -10,6 +10,7 @@ import {
   tatieSideType,
   subAlignmentSideType,
   tatieOrderListType,
+  tatieColorOption,
 } from '../type/data-type'
 import {
   DEFAULT_KYARA_TATIE_UUID,
@@ -55,6 +56,7 @@ export const createNewDateList = (
     tatiePwPs?: number
     tatiePhPs?: number
     rotate?: number
+    colorEdit?: tatieColorOption
     fps?: number
   },
   subtitle?: {
@@ -110,6 +112,16 @@ export const createNewDateList = (
       tatiePwPs: { val: tatie.tatiePwPs ?? 0, active: tatie.tatiePwPs !== undefined ? true : dataType === 'defo' },
       tatiePhPs: { val: tatie.tatiePhPs ?? 0, active: tatie.tatiePhPs !== undefined ? true : dataType === 'defo' },
       rotate: { val: tatie.rotate ?? 0, active: tatie.rotate !== undefined ? true : dataType === 'defo' },
+      colorEdit: {
+        val: tatie.colorEdit ?? {
+          selectStyle: 'default',
+          colorspaceOption: 'gray',
+          negateOption: '',
+          monochromeOption: '',
+          sepiaToneOption: 80,
+        },
+        active: tatie.colorEdit !== undefined ? true : dataType === 'defo',
+      },
       fps: { val: tatie.fps ?? 6, active: tatie.fps !== undefined ? true : dataType === 'defo' },
     },
     subtitle: {

--- a/src/utils/analysisMain.ts
+++ b/src/utils/analysisMain.ts
@@ -730,7 +730,7 @@ export const loadKyaraProfileData = async (confPath: string): Promise<string> =>
   // 古い設定ファイルだった場合、必要な項目を追加します。
 
   // var 0.2 以下の場合
-  // waitTatieUUID と rotate と tatieOrderList がないので追加する
+  // waitTatieUUID,  rotate, colorEdit と tatieOrderList がないので追加する
   await new Promise((resolve, reject) => {
     if (inputJsonData.softVer[0] <= 0 && inputJsonData.softVer[1] <= 2) {
       console.log('var 0.2 以下の場合')
@@ -763,6 +763,16 @@ export const loadKyaraProfileData = async (confPath: string): Promise<string> =>
                 },
                 rotate: {
                   val: 0,
+                  active: item.dataType === 'defo' ? true : false,
+                },
+                colorEdit: {
+                  val: {
+                    selectStyle: 'default',
+                    colorspaceOption: 'gray',
+                    negateOption: '',
+                    monochromeOption: '',
+                    sepiaToneOption: 80,
+                  },
                   active: item.dataType === 'defo' ? true : false,
                 },
               },
@@ -803,7 +813,7 @@ export const loadVoiceFileData = async (confPath: string): Promise<string> => {
   // 古い設定ファイルだった場合、必要な項目を追加します。
 
   // var 0.2 以下の場合
-  // waitTatieUUID と rotate と tatieOrderList がないので追加する
+  // waitTatieUUID,  rotate, colorEdit と tatieOrderList がないので追加する
   await new Promise((resolve, reject) => {
     if (inputJsonData.softVer[0] <= 0 && inputJsonData.softVer[1] <= 2) {
       console.log('var 0.2 以下の場合')
@@ -834,6 +844,16 @@ export const loadVoiceFileData = async (confPath: string): Promise<string> => {
                 },
                 rotate: {
                   val: 0,
+                  active: item.dataType === 'defo' ? true : false,
+                },
+                colorEdit: {
+                  val: {
+                    selectStyle: 'default',
+                    colorspaceOption: 'gray',
+                    negateOption: '',
+                    monochromeOption: '',
+                    sepiaToneOption: 80,
+                  },
                   active: item.dataType === 'defo' ? true : false,
                 },
               },

--- a/src/utils/analysisMain.ts
+++ b/src/utils/analysisMain.ts
@@ -694,9 +694,9 @@ export const loadGlobalSettingData = async (confPath: string): Promise<string> =
       // 追加したデータを書き込む
       const out = outSoftVersion()
       return JSON.stringify(
-        {
+        <globalSettingExportType>{
           exportStatus: out.exportStatus,
-          softVar: out.softVer,
+          softVer: out.softVer,
           globalSetting: {
             ...result,
             useSubText: true,
@@ -744,8 +744,8 @@ export const loadKyaraProfileData = async (confPath: string): Promise<string> =>
       const out = outSoftVersion()
       const tatieOrder: tatieOrderListType[] = []
       return JSON.stringify(
-        {
-          softVar: out.softVer,
+        <profileKyaraExportType>{
+          softVer: out.softVer,
           exportStatus: out.exportStatus,
           infoSetting: inputJsonData.infoSetting,
           tatieOrderList: tatieOrder,
@@ -827,8 +827,8 @@ export const loadVoiceFileData = async (confPath: string): Promise<string> => {
       const out = outSoftVersion()
       const tatieOrder: tatieOrderListType[] = []
       return JSON.stringify(
-        {
-          softVar: out.softVer,
+        <profileVoiceFileExportType>{
+          softVer: out.softVer,
           exportStatus: out.exportStatus,
           settingList: inputJsonData.settingList.map((item) => {
             return {

--- a/src/utils/comExec/comIMG.ts
+++ b/src/utils/comExec/comIMG.ts
@@ -1,6 +1,6 @@
 // このファイルはメイン側で利用するため、レンダラー側では読み込めない
 // ImageMagic関連のコマンドを記載
-import { outSettingType } from '../../type/data-type'
+import { outSettingType, tatieColorOption } from '../../type/data-type'
 
 // 設定情報を元にImageMagicに送付するコマンドを作成
 // これをメイン側に送って画像作成を行う
@@ -53,6 +53,20 @@ export const createComImg = async (fileSetting: outSettingType): Promise<createC
   }
   const tatieSignH = await selectTatieSignH()
 
+  // 立ち絵の色を加工する場合は内容を指定する
+  const TatieColorEdit = (colorEdit: tatieColorOption): string[] => {
+    switch (colorEdit.selectStyle) {
+      case 'colorspace':
+        return ['-colorspace', 'gray']
+      case 'negate':
+        return ['-negate']
+      case 'sepiaTone':
+        return ['-sepia-tone', colorEdit.sepiaToneOption.toString() + '%']
+      default:
+        return []
+    }
+  }
+
   // 結果を出力する
   return {
     //// 元の立ち絵を設定に応じて縮小するコマンドを作成
@@ -67,7 +81,7 @@ export const createComImg = async (fileSetting: outSettingType): Promise<createC
       'none',
       '-rotate',
       fileSetting.tatie.rotate.val.toString(),
-    ],
+    ].concat(TatieColorEdit(fileSetting.tatie.colorEdit.val)),
     //// 動画の画面サイズの透明な画像を生成するコマンドを作成
     // convert -size ${画像の幅}x${画像の高さ} xc:none 透明な画面サイズの出力ファイル（一時的）.png
     //


### PR DESCRIPTION
## Pull Request 概要

立ち絵の色を加工できる機能を追加します。

## 変更点

下記の加工方法を追加できるようにします。

- グレースケール
- カラー反転
- セピア調

## その他

モノクロ2階調については透過情報を削除してしまうため、今回は実装を見送りました。

