### PR TITLE
字幕を動画の上部に配置できるようにする

### DIFF
--- a/src/components/accessories/SelectDisplaySubAlignmentSide.vue
+++ b/src/components/accessories/SelectDisplaySubAlignmentSide.vue
@@ -23,9 +23,14 @@ const actset = (side: subAlignmentSideType): string => {
   <div class="fixed top-0 right-0 flex h-screen w-screen items-center justify-center" @click.self="clickClose">
     <!-- 画面外クリックでクローズ -->
   </div>
-  <div class="absolute flex" @click="clickClose">
-    <button :class="actset('Left')" @click="changeSubAlignmentSide('Left')">左寄せ</button>
-    <button :class="actset('Center')" @click="changeSubAlignmentSide('Center')">中央寄せ</button>
-    <button :class="actset('Right')" @click="changeSubAlignmentSide('Right')">右寄せ</button>
+  <div class="absolute border-2 border-gray-600 bg-blue-100" @click="clickClose">
+    <div class="flex justify-center">
+      <button :class="actset('topCnter')" @click="changeSubAlignmentSide('topCnter')">上部中央寄せ</button>
+    </div>
+    <div class="flex">
+      <button :class="actset('Left')" @click="changeSubAlignmentSide('Left')">左寄せ</button>
+      <button :class="actset('Center')" @click="changeSubAlignmentSide('Center')">中央寄せ</button>
+      <button :class="actset('Right')" @click="changeSubAlignmentSide('Right')">右寄せ</button>
+    </div>
   </div>
 </template>

--- a/src/components/setSubtitle.vue
+++ b/src/components/setSubtitle.vue
@@ -34,15 +34,14 @@ import EditDisplaySubtitleSubAlignmentKyaraData from '@/components/accessories/E
       editName="フォントファイル"
       titleName="フォントファイルを指定します"
     />
-    <!-- 文字を寄せる方向 -->
     <EditDisplaySubtitleSubAlignmentKyaraData
       :settype="settype"
       :dateList="dateList"
       :selectKyara="selectKyara"
       :higherUpList="higherUpList"
       subtitleSetting="subAlignment"
-      editName="文字を寄せる方向"
-      titleName="文字を左右中央のどこに寄せるか指定します"
+      editName="文字の位置"
+      titleName="文字の位置を指定します"
     />
     <EditDisplaySubtitleCheckboxKyaraData
       :settype="settype"
@@ -88,9 +87,9 @@ import EditDisplaySubtitleSubAlignmentKyaraData from '@/components/accessories/E
       :selectKyara="selectKyara"
       :higherUpList="higherUpList"
       subtitleSetting="subTextSpaceSize"
-      editName="文字下の空白(px)"
+      editName="動画端の空白(px)"
       inputMin="0"
-      titleName="字幕の下に隙間を配置します"
+      titleName="字幕と動画端との間に隙間を配置します"
     />
     <EditDisplaySubtitleColorKyaraData
       :settype="settype"

--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -36,6 +36,7 @@ export const subAlignmentView: { [key in subAlignmentSideType]: string } = {
   Left: '左寄せ',
   Right: '右寄せ',
   Center: '中央寄せ',
+  topCnter: '上部中央寄せ',
 }
 
 // 各キャラ設定タイプの色を決定する

--- a/src/type/data-type.ts
+++ b/src/type/data-type.ts
@@ -18,12 +18,12 @@ export type tatieSetting = {
 export type subtitleSetting = {
   subText: statusBoolean // 字幕を表示するかどうか
   fontsPath: statusString // フォントのパス
-  subAlignment: statusSubAlignment // 文字を寄せる方向
+  subAlignment: statusSubAlignment // 字幕の位置
   subAutoRt: statusBoolean // 自動改行を有効化
   subTextBord: statusBoolean // 文字のフチに色をつける
   subBG: statusBoolean // 字幕に背景色をつける
   subSize: statusNumber // フォントサイズ
-  subTextSpaceSize: statusNumber // 背景色をつけない時の、文字下の空きスペース
+  subTextSpaceSize: statusNumber // 背景色をつけない時の、字幕と動画端との間に配置する隙間
   subColor: statusString //フォントカラー
   subOrdercr: statusString // フォントのフチの色
   subBorderW: statusNumber // フォント周りのフチの大きさ

--- a/src/type/data-type.ts
+++ b/src/type/data-type.ts
@@ -149,8 +149,8 @@ export type tatieColorOption = {
 // 立ち絵の色の加工スタイル
 export type tatieColorSelectStyleType = 'colorspace' | 'negate' | 'sepiaTone' | 'default'
 
-// 字幕の文字列をどちらに寄せるか（左 右 中央）
-export type subAlignmentSideType = 'Left' | 'Right' | 'Center' | null
+// 字幕の文字列をどちらに寄せるか（左 右 中央 上部中央）
+export type subAlignmentSideType = 'Left' | 'Right' | 'Center' | 'topCnter' | null
 
 // キャラ名とスタイル名のみ
 export type editKyaraNameType = {

--- a/src/utils/comExec/comMOVI.ts
+++ b/src/utils/comExec/comMOVI.ts
@@ -142,12 +142,18 @@ export const makeTextList = async (
   console.log('textList: ' + textList)
   let ans = ''
 
-  for await (const line of textList) {
+  for await (const [index, line] of textList.entries()) {
+    // 字幕位置が上部中央寄せの場合は、
+    // subTextSpaceSizeは上の方の隙間の値として使用する。
+    const drawtext_y =
+      fileSetting.subtitle.subAlignment.val === 'topCnter'
+        ? `${fileSetting.subtitle.subTextSpaceSize.val}+(${index}*${fileSetting.subtitle.subSize.val})`
+        : `h-(((${fileSetting.subtitle.subSize.val})*${textLineLength})+${fileSetting.subtitle.subTextSpaceSize.val})`
     ans +=
       `,drawtext=fontfile='${fileSetting.subtitle.fontsPath.val.replace(/\\/g, '\\\\').replace(/:\\/g, '\\:\\')}':` +
       `textfile='${line}':fontcolor=${fileSetting.subtitle.subColor.val}:` +
       `${subTextBord}fontsize=${fileSetting.subtitle.subSize.val}:` +
-      `x=${subSide}:y=h-(((${fileSetting.subtitle.subSize.val})*${textLineLength})+${fileSetting.subtitle.subTextSpaceSize.val})`
+      `x=${subSide}:y=${drawtext_y}`
 
     // 文字列をひとつ出力したので、次の文字がその下に表示されるように textLineLength の値をひとつ少なくします。
     textLineLength--


### PR DESCRIPTION
## Pull Request 概要

字幕を動画の上部に配置できるように、機能を追加します。

## 変更点

- 字幕位置の設定に`上部中央寄せ`を追加
- 項目の説明内容を修正

## その他


