### PR TITLE
立ち絵順序の設定で設定キャラを変更する際に、キャラ名で検索した状態でリストを開く

### DIFF
--- a/src/components/accessories/SelectDisplayTatieOrderKyara.vue
+++ b/src/components/accessories/SelectDisplayTatieOrderKyara.vue
@@ -15,7 +15,7 @@ const props = defineProps<{
 
 import { ref } from 'vue'
 import type { outSettingType, dataTextType } from 'src/type/data-type'
-import { typeColor } from '@/data/data'
+import { typeColor, DEFAULT_KYARA_SETTING_DISPLAY_NAME } from '@/data/data'
 import { MakeClassString } from '@/utils/analysisGeneral'
 import { FindAllString } from '@/utils/analysisData'
 import SearchInputUnit from '@/components/unit/SearchInputUnit.vue'
@@ -43,7 +43,12 @@ const KyaraChange = (outSetting: outSettingType): void => {
   </div>
   <div class="fixed top-1/3 flex w-96 flex-col rounded-xl border-1 border-gray-800 bg-blue-100 px-5 py-4 text-sm">
     <div class="h-80 overflow-y-scroll border border-gray-600">
-      <SearchInputUnit classSetting="bg-gray-300" inputTitle="立ち絵名かキャラ名で検索" ref="refSearchString" />
+      <SearchInputUnit
+        :defaultString="selectKyaraName !== DEFAULT_KYARA_SETTING_DISPLAY_NAME ? selectKyaraName : undefined"
+        classSetting="bg-gray-300"
+        inputTitle="立ち絵名かキャラ名で検索"
+        ref="refSearchString"
+      />
       <div class="">
         <div v-for="item in kyaraProfileList" v-bind:key="item.uuid">
           <button

--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -8,8 +8,14 @@ import { tatieSideType, subAlignmentSideType } from '../type/data-type'
 // デフォルトのキャラ設定プロファイル名
 export const DEFAULT_KYARA_PROFILE_NAME = 'default'
 
+// デフォルトのキャラ設定プロファイルの画面上の表示名
+export const DEFAULT_KYARA_PROFILE_DISPLAY_NAME = 'デフォルト'
+
 // デフォルトのキャラ設定につけるUUID
 export const DEFAULT_KYARA_SETTING_UUID = '0'
+
+// デフォルトのキャラ設定の表示名
+export const DEFAULT_KYARA_SETTING_DISPLAY_NAME = 'デフォルト'
 
 // デフォルトの立ち絵のUUID
 export const DEFAULT_KYARA_TATIE_UUID = '0'

--- a/src/utils/analysisGeneral.ts
+++ b/src/utils/analysisGeneral.ts
@@ -15,7 +15,9 @@ import {
 import {
   DEFAULT_KYARA_TATIE_UUID,
   DEFAULT_KYARA_PROFILE_NAME,
+  DEFAULT_KYARA_PROFILE_DISPLAY_NAME,
   DEFAULT_KYARA_SETTING_UUID,
+  DEFAULT_KYARA_SETTING_DISPLAY_NAME,
   DEFAULT_FONT_WIN,
   DEFAULT_FONT_LINUX,
 } from '../data/data'
@@ -33,7 +35,7 @@ export const createDefoInfoDateList = (): infoSettingType => {
 export const createDefoKyaraProfileList = (): kyaraProfileListType => {
   return {
     uuid: DEFAULT_KYARA_PROFILE_NAME,
-    displayName: 'デフォルト',
+    displayName: DEFAULT_KYARA_PROFILE_DISPLAY_NAME,
   }
 }
 
@@ -225,7 +227,15 @@ export const createNewDateList = (
 
 // デフォルトのキャラ設定データを作成して返す
 export const createDefoKyaraDateList = (platform: NodeJS.Platform): outSettingType => {
-  return createNewDateList(platform, 'defo', DEFAULT_KYARA_SETTING_UUID, 'デフォルト', undefined, {}, {})
+  return createNewDateList(
+    platform,
+    'defo',
+    DEFAULT_KYARA_SETTING_UUID,
+    DEFAULT_KYARA_SETTING_DISPLAY_NAME,
+    undefined,
+    {},
+    {},
+  )
 }
 
 // デフォルトのキャラUUIDリストデータを作成して返す


### PR DESCRIPTION
## Pull Request 概要

立ち絵順序の設定で設定キャラを変更する際に、キャラ名で検索した状態でリストを開くように改良します。

## 変更点


## その他


