### PR TITLE
音声ファイルなどに記載のキャラ名の判別を、スペース切りのand検索にする #1577

### DIFF
--- a/src/components/accessories/DisplaySampleList.vue
+++ b/src/components/accessories/DisplaySampleList.vue
@@ -18,13 +18,13 @@ import type {
   tatieOrderListType,
   dataTextType,
 } from '@/type/data-type'
-import { createVoiceFileEncodeSetting, FindAllString } from '@/utils/analysisData'
+import { createVoiceFileEncodeSetting } from '@/utils/analysisData'
 import { makeTatiePicEncodeList, EnterEncodeSaveTatieFile } from '@/utils/analysisFile'
 import { DEFAULT_KYARA_TATIE_UUID } from '@/data/data'
 import { onUnmounted, ref, watch } from 'vue'
 import DisplaySampleView from '@/components/accessories/DisplaySampleView.vue'
 import DialogRawLIstFileView from '@/components/unit/DialogRawLIstFileView.vue'
-import { MakeClassString, resizeKyaraDateDisplay } from '@/utils/analysisGeneral'
+import { MakeClassString, resizeKyaraDateDisplay, FindAllString } from '@/utils/analysisGeneral'
 
 // サムネイル用
 const refDisplaySampleView = ref<{ [key: string]: InstanceType<typeof DisplaySampleView> | null }>({})

--- a/src/components/accessories/SelectDisplayTatieFile.vue
+++ b/src/components/accessories/SelectDisplayTatieFile.vue
@@ -18,8 +18,7 @@ import type { fileListTatieType } from 'src/type/data-type'
 import MaterialIcons from '@/components/accessories/icons/MaterialIcons.vue'
 import DisplayTatiePicFile from '@/components/accessories/DisplayTatiePicFile.vue'
 import { DEFAULT_KYARA_TATIE_UUID } from '@/data/data'
-import { MakeClassString } from '@/utils/analysisGeneral'
-import { FindAllString } from '@/utils/analysisData'
+import { MakeClassString, FindAllString } from '@/utils/analysisGeneral'
 import SearchInputUnit from '@/components/unit/SearchInputUnit.vue'
 
 const refSearchString = ref<{ searchString: string }>({ searchString: undefined })

--- a/src/components/accessories/SelectDisplayTatieOrderKyara.vue
+++ b/src/components/accessories/SelectDisplayTatieOrderKyara.vue
@@ -16,8 +16,7 @@ const props = defineProps<{
 import { ref } from 'vue'
 import type { outSettingType, dataTextType } from 'src/type/data-type'
 import { typeColor, DEFAULT_KYARA_SETTING_DISPLAY_NAME } from '@/data/data'
-import { MakeClassString } from '@/utils/analysisGeneral'
-import { FindAllString } from '@/utils/analysisData'
+import { MakeClassString, FindAllString } from '@/utils/analysisGeneral'
 import SearchInputUnit from '@/components/unit/SearchInputUnit.vue'
 
 // 検索用

--- a/src/components/makeComList.vue
+++ b/src/components/makeComList.vue
@@ -36,11 +36,10 @@ import {
   loadProfile,
   writeGlobalSetting,
   getPlatform,
-  FindAllString,
   CreateCopyDateList,
 } from '@/utils/analysisData'
 import { DEFAULT_KYARA_SETTING_UUID } from '@/data/data'
-import { createDefoKyaraDateList, createNewDateList } from '@/utils/analysisGeneral'
+import { createDefoKyaraDateList, createNewDateList, FindAllString } from '@/utils/analysisGeneral'
 import type { deleteDialogRefType } from 'src/components/accessories/deleteDialog.vue'
 import deleteDialog from '@/components/accessories/deleteDialog.vue'
 import DisplaySelectFileView from '@/components/accessories/DisplaySelectFileView.vue'

--- a/src/components/makeComList.vue
+++ b/src/components/makeComList.vue
@@ -156,8 +156,9 @@ const addNewKyara = (dataType: dataTextType, kyaraName: string, kyaraStyle: stri
   try {
     // 同じキャラ設定がない場合は追加する。
     if (
-      dateList.value.find((e) => e.name === kyaraName && e.dataType === dataType && e.kyaraStyle === kyaraStyle) ===
-      undefined
+      dateList.value.find(
+        (e) => FindAllString(e.name, [kyaraName]) && e.dataType === dataType && e.kyaraStyle === kyaraStyle,
+      ) === undefined
     ) {
       console.log('追加')
       dateList.value.push(

--- a/src/components/setKyaraList.vue
+++ b/src/components/setKyaraList.vue
@@ -25,14 +25,14 @@ const props = defineProps<{
 }>()
 import { watch, ref, nextTick } from 'vue'
 import { outSettingType, dataTextType, editKyaraNameType } from '@/type/data-type'
-import { checkSameValues, FindAllString, getPlatform } from '@/utils/analysisData'
+import { checkSameValues, getPlatform } from '@/utils/analysisData'
 import AccEditKyaraName from '@/components/accessories/AccEditKyaraName.vue'
 import MaterialIcons from '@/components/accessories/icons/MaterialIcons.vue'
 import SelectProfileList from '@/components/unit/SelectProfileList.vue'
 import SearchInputUnit from '@/components/unit/SearchInputUnit.vue'
 import SelectDisplayKyaraRightClickMenu from '@/components/accessories/SelectDisplayKyaraRightClickMenu.vue'
 import SelectSeidList from '@/components/unit/SelectSeidList.vue'
-import { MakeClassString, createNewDateList } from '@/utils/analysisGeneral'
+import { MakeClassString, createNewDateList, FindAllString } from '@/utils/analysisGeneral'
 
 const { yomAPI } = window
 

--- a/src/data/defoKyara.ts
+++ b/src/data/defoKyara.ts
@@ -523,6 +523,7 @@ export const initializationSettingData: initializationSettingType[] = [
     kyaraName: 'galaco',
     subColor: '#9a0d7c',
     subOrdercr: '#ffffff',
+    kyaraStyle: ['平静', '喜び', '怒り', '悲しみ'],
   },
   // CeVIO AI
   {
@@ -557,6 +558,11 @@ export const initializationSettingData: initializationSettingType[] = [
     subColor: '#bbe2f1',
     subOrdercr: '#0075c2',
   },
+  {
+    kyaraName: 'ついなちゃん',
+    subColor: '#ff0f0f',
+    subOrdercr: '#383838',
+  },
   // ガイノイドTalk
   {
     kyaraName: 'flower',
@@ -567,10 +573,12 @@ export const initializationSettingData: initializationSettingType[] = [
     kyaraName: '鳴花ヒメ',
     subColor: '#e7609e',
     subOrdercr: '#ffffff',
+    kyaraStyle: ['平静', '喜び', '怒り', '悲しみ', 'デカボイス'],
   },
   {
     kyaraName: '鳴花ミコト',
     subColor: '#bbbcde',
     subOrdercr: '#0d0015',
+    kyaraStyle: ['平静', '喜び', '怒り', '悲しみ', 'デカボイス'],
   },
 ]

--- a/src/utils/analysisData.ts
+++ b/src/utils/analysisData.ts
@@ -402,28 +402,3 @@ export const loadProfile = (profileName?: string): inputProfileSendReType => {
   // JSONファイル読み込み
   return yomAPI.getKyaraProfileData(inputProfileName)
 }
-
-// 第１引数で指定された文字列で、第２引数で指定された文字列を検索する。
-// 第１引数の文字列は半角・全角スペースで分割しAND検索を行う。
-export const FindAllString = (searchString: string | undefined, findList: string[]): boolean => {
-  // 検索文字列がない場合はtrueを返す
-  if (searchString === undefined || searchString === '') {
-    return true
-  }
-
-  const splitSearchString = searchString.replaceAll('　', ' ').split(' ')
-
-  // 検索対象文字列を半角スペースで区切って一つの文字列にする
-  const findString = findList.join(' ')
-
-  // 検索対象文字列を検索して、ひとつでも検索文字列が見つからなければfalseを返す。
-  // and検索のため
-  for (const val of splitSearchString) {
-    if (findString.indexOf(val) === -1) {
-      return false
-    }
-  }
-
-  // 検索文字列がすべてあればtrueを返す。
-  return true
-}

--- a/src/utils/analysisData.ts
+++ b/src/utils/analysisData.ts
@@ -12,7 +12,7 @@ import {
   kyaraProfileListExportType,
   kyaraProfileListType,
 } from '../type/data-type'
-import { NowTimeData, createNewDateList } from './analysisGeneral'
+import { NowTimeData, createNewDateList, FindAllString } from './analysisGeneral'
 import { DEFAULT_KYARA_PROFILE_NAME } from '../data/data'
 import { ref } from 'vue'
 
@@ -80,10 +80,12 @@ export const ansFindIndex = (kyaraType: 'kyast' | 'kyara', dateList: outSettingT
       (e) =>
         e.dataType === 'kyast' &&
         e.kyaraStyle === dateList[selectKyara]?.kyaraStyle &&
-        e.name === dateList[selectKyara]?.name,
+        FindAllString(e.name, [dateList[selectKyara]?.name]),
     )
   } else {
-    ansFindIndex.value = dateList.findIndex((e) => e.dataType === 'kyara' && e.name === dateList[selectKyara]?.name)
+    ansFindIndex.value = dateList.findIndex(
+      (e) => e.dataType === 'kyara' && FindAllString(e.name, [dateList[selectKyara]?.name]),
+    )
   }
 
   if (ansFindIndex.value !== -1) {

--- a/src/utils/analysisData.ts
+++ b/src/utils/analysisData.ts
@@ -18,35 +18,10 @@ import { ref } from 'vue'
 
 const { yomAPI } = window
 
-// outSettingType形式の変数を比較し同一かどうか判定する。
-export const analysisDataComparisonOutSettingType = (element: outSettingType, target: outSettingType): boolean => {
-  return (
-    element.dataType === target.dataType && element.name === target.name && element.kyaraStyle === target.kyaraStyle
-  )
-}
-
 // 与えられた文字列からハッシュを作成
 // ID用に使う
 export const createStringHash = (data: string): number => {
   return yomAPI.getHashData(data)
-}
-
-// dateListに新しいデータを入れる際に、他と衝突していないIDを作成する
-export const createNewDataID = (dateList: outSettingType[], newName: string): number => {
-  let newID = <number>0
-
-  newID = createStringHash(newName) // 重ならないように現在時刻を追加
-
-  // 同じIDが作られたら、現在時刻を加えて再作成、それでだめならエラー
-  if (dateList.findIndex((e) => e.uuid === newID.toString()) !== -1) {
-    newID = createStringHash(newName + new Date().getTime()) // 重ならないように現在時刻を追加
-
-    if (dateList.findIndex((e) => e.uuid === newID.toString()) !== -1) {
-      return -1
-    }
-  }
-
-  return newID
 }
 
 // 動作環境がlinuxかWindowsか取得する

--- a/src/utils/analysisGeneral.ts
+++ b/src/utils/analysisGeneral.ts
@@ -323,3 +323,28 @@ export const resizeKyaraDateDisplay = (setting: outSettingType, size?: { w: numb
     return setting
   }
 }
+
+// 第１引数で指定された文字列で、第２引数で指定された文字列を検索する。
+// 第１引数の文字列は半角・全角スペースで分割しAND検索を行う。
+export const FindAllString = (searchString: string | undefined, findList: string[]): boolean => {
+  // 検索文字列がない場合はtrueを返す
+  if (searchString === undefined || searchString === '') {
+    return true
+  }
+
+  const splitSearchString = searchString.replaceAll('　', ' ').split(' ')
+
+  // 検索対象文字列を半角スペースで区切って一つの文字列にする
+  const findString = findList.join(' ')
+
+  // 検索対象文字列を検索して、ひとつでも検索文字列が見つからなければfalseを返す。
+  // and検索のため
+  for (const val of splitSearchString) {
+    if (findString.indexOf(val) === -1) {
+      return false
+    }
+  }
+
+  // 検索文字列がすべてあればtrueを返す。
+  return true
+}


### PR DESCRIPTION
## Pull Request 概要

音声ファイルなどに記載のキャラ名の判別を、スペース切りのand検索にします。

これは、同じキャラでもソフトによって姓名の間にスペースが入っている場合とそうでない場合があるためで、
両方とも一つのキャラ設定で対応できるようにします。

## 変更点


## その他


