### PR TITLE
Tempディレクトリを変更できるようにする

### DIFF
--- a/src/components/accessories/GlobalSetting/MainSetting.vue
+++ b/src/components/accessories/GlobalSetting/MainSetting.vue
@@ -7,6 +7,7 @@ import { ref, watch } from 'vue'
 import { globalSettingType } from '@/type/data-type'
 import { getGlobalSetting, writeGlobalSetting } from '@/utils/analysisData'
 import { MakeClassString } from '@/utils/analysisGeneral'
+import { changeDirPath } from '@/utils/analysisFile'
 
 // 全体設定を読み込み
 const globalSettingList = ref<globalSettingType>(getGlobalSetting())
@@ -18,6 +19,17 @@ const seveStatus = ref<boolean>(false)
 const saveEnter = (): void => {
   const ans = writeGlobalSetting(globalSettingList.value)
   seveStatus.value = !ans
+}
+
+const changeDir = async (path: string, title: string): Promise<void> => {
+  const ans = await changeDirPath(path, title)
+
+  console.log(ans)
+
+  // null やundefinedでなければ書き込む
+  if (ans ?? false) {
+    globalSettingList.value.cacheDirPath = ans
+  }
 }
 
 // 設定に編集があったときにはtrueを入れる
@@ -70,6 +82,21 @@ watch(
           <div class="mx-2 my-1 text-xl font-medium">ファイルリストで字幕の内容を表示</div>
           <div class="mx-2 mt-1 flex items-center p-1">
             <input class="" type="checkbox" v-model="globalSettingList.useSubText" />
+          </div>
+        </div>
+      </div>
+      <div class="mt-1 bg-gray-100 py-2">
+        <div class="text-2xl">キャッシュ保存領域の設定</div>
+        <div>
+          <div class="mt-3 text-xl font-medium">キャッシュ保存場所</div>
+          <div class="mx-2 mt-1 p-1">
+            <button
+              class="w-full truncate rounded-md border border-gray-600 bg-sky-300 px-2 py-1 hover:bg-sky-500"
+              title="キャッシュ保存場所を変更できます"
+              @click="changeDir('test', 'キャッシュ保存場所')"
+            >
+              {{ globalSettingList.cacheDirPath }}
+            </button>
           </div>
         </div>
       </div>

--- a/src/type/data-type.ts
+++ b/src/type/data-type.ts
@@ -253,6 +253,7 @@ export type globalSettingType = {
     convert: string
   }
   useSubText: boolean // 音声ファイルリストで字幕の内容を表示するかどうか
+  cacheDirPath: string // 加工済み立ち絵画像ファイル等を保存するディレクトリの絶対パス
 }
 
 // var 0.2.1 以下の場合

--- a/src/utils/analysisMain.ts
+++ b/src/utils/analysisMain.ts
@@ -37,13 +37,14 @@ import path from 'path'
 import fs from 'fs'
 
 // 作業用の一時ファイルを設置するディレクトリを作成する。
-export const createTempDir = async (): Promise<string> => {
+export const createTempDir = async (dirPath?: string): Promise<string> => {
   const makeTempDir = async (dir: string) => {
-    fs.mkdirSync(dir)
+    fs.mkdirSync(dir, { recursive: true })
   }
 
   // temp領域に専用のディレクトリを作成してそのパスを返す。
-  const yomTempRoot = path.join(app.getPath('temp'), 'YOMtempDir')
+  // dirPathが設定されている場合はその値をそのまま入れる。
+  const yomTempRoot = dirPath !== undefined ? dirPath : path.join(app.getPath('temp'), 'YOMtempDir')
 
   // ディレクトリがあるか確認する
   new Promise((resolve) => {
@@ -179,6 +180,7 @@ export const initializationGlobalSetting = (): globalSettingExportType => {
             : '/usr/bin/convert',
       },
       useSubText: true,
+      cacheDirPath: path.join(app.getPath('temp'), 'YOMcacheDir'),
     },
   }
 }
@@ -427,7 +429,7 @@ export const enterEncodeVideoData = async (
   const infoSetting: infoSettingType = JSON.parse(infoSettingJsonData)
 
   // 一時ファイルのディレクトリを作成してpathを取得
-  const tempDirPath = await createTempDir()
+  const tempDirPath = await createTempDir(globalSetting.cacheDirPath)
 
   //// 画像ファイルの作成
 
@@ -469,7 +471,7 @@ export const enterEncodePicFileData = async (
   globalSetting: globalSettingType,
 ): Promise<{ buffer: Uint8Array; path: string }> => {
   // 一時ファイルのディレクトリを作成してpathを取得
-  const tempDirPath = await createTempDir()
+  const tempDirPath = await createTempDir(globalSetting.cacheDirPath)
 
   console.log('長さ; ' + outState.length)
 

--- a/src/utils/analysisMain.ts
+++ b/src/utils/analysisMain.ts
@@ -726,8 +726,8 @@ export const loadGlobalSettingData = async (confPath: string): Promise<string> =
   await new Promise((resolve, reject) => {
     if (inputJsonData.softVer[0] <= 0 && inputJsonData.softVer[1] <= 2 && inputJsonData.softVer[2] <= 1) {
       console.log('var 0.2.1 以下の場合')
-      const inputJsonV021Data: globalSettingExportV021Type = JSON.parse(jsonData.value)
-      resolve(inputJsonV021Data.globalSetting)
+      const inputJsonTempData: globalSettingExportType = JSON.parse(jsonData.value)
+      resolve(inputJsonTempData.globalSetting)
     } else {
       reject()
     }
@@ -743,6 +743,49 @@ export const loadGlobalSettingData = async (confPath: string): Promise<string> =
           globalSetting: {
             ...result,
             useSubText: true,
+          },
+        },
+        undefined,
+        2,
+      )
+    })
+    .then((result: string) => {
+      return writeJsonData(confPath, result)
+    })
+    .then(() => {
+      console.log('再読込')
+      jsonData.value = readJsonData(confPath)
+    })
+    .catch(() => {
+      console.log('問題なし')
+    })
+
+  // var 0.3.0 以下の場合
+  // cacheDirPath がないので追加する
+  await new Promise((resolve, reject) => {
+    if (inputJsonData.softVer[0] <= 0 && inputJsonData.softVer[1] <= 3 && inputJsonData.softVer[2] <= 0) {
+      console.log('var 0.3.0 以下の場合')
+      const inputJsonTempData: globalSettingExportType = JSON.parse(jsonData.value)
+      resolve(inputJsonTempData.globalSetting)
+    } else {
+      reject()
+    }
+  })
+    .then((result: globalSettingType) => {
+      console.log('追加したデータを書き込む')
+      // 追加したデータを書き込む
+      const out = outSoftVersion()
+
+      // 最新のデフォルト設定を作成
+      const defoData = initializationGlobalSetting()
+
+      return JSON.stringify(
+        <globalSettingExportType>{
+          exportStatus: out.exportStatus,
+          softVer: [0, 3, 1],
+          globalSetting: {
+            ...result,
+            cacheDirPath: defoData.globalSetting.cacheDirPath,
           },
         },
         undefined,


### PR DESCRIPTION
## Pull Request 概要

Tempディレクトリを恒久的な場所に変更できるようにして、再起動しても加工済み立ち絵のキャッシュが消えないようにします。

これにより、エンコード処理をさらに効率化します。

## 変更点


## その他


